### PR TITLE
#15 Add Dependabot config for npm and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,40 @@
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      # Routine bumps arrive as one PR that can be merged on the strength of CI.
+      npm-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+      # Breaking changes arrive separately, so they never hold up the above.
+      npm-major:
+        patterns:
+          - "*"
+        update-types:
+          - major
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      actions-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+      actions-major:
+        patterns:
+          - "*"
+        update-types:
+          - major


### PR DESCRIPTION
Closes #15.

Adds `.github/dependabot.yml` for npm and GitHub Actions, weekly.

Minor and patch updates are grouped into one PR per ecosystem, majors into another. Routine bumps then arrive as a single PR that CI has actually exercised — build, lint, unit and integration all run on it — and a breaking change never rides along with them.

`open-pull-requests-limit` is 5 per ecosystem.

One thing to watch: batching every major into one PR means a single incompatible package blocks the others in that batch. If that gets annoying, splitting the major group per-package is the escape hatch.

Config-only change, nothing to test locally. Dependabot validates the file itself once it is on `main` — Insights → Dependency graph → Dependabot will show a parse error there if anything is wrong.
