### PR TITLE
#16 Exclude node_modules from the YAML scan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ node_modules
 .vscode-test/
 *.vsix
 coverage
+
+# The test fixture deliberately holds a node_modules directory: the scan has to
+# be proven to skip it, which needs it committed.
+!src/test/fixtures/drupal-site/node_modules/

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -53,7 +53,14 @@ recipes/recipe_actions/recipe.yml                config action paths
 web/core/recipes/core_test_recipe/recipe.yml     a recipe to suggest
 web/modules/contrib/recipe_test_module/          info, permissions and config
 web/themes/contrib/recipe_test_theme/            a theme to suggest
+vendor/…/modules/vendored_module/                must never be suggested
+node_modules/…/modules/bundled_module/           must never be suggested
 ```
+
+The last two are module-shaped files inside dependency directories. The scan
+excludes `vendor` and `node_modules` at any depth, and the integration suite
+holds it to that. `.gitignore` re-includes the fixture's `node_modules` so it
+can be committed.
 
 The extension only activates when the workspace `composer.json` requires
 `drupal/core-recommended`, which is why the fixture has one.

--- a/src/base/drupal-workspace-yaml-discovery.ts
+++ b/src/base/drupal-workspace-yaml-discovery.ts
@@ -20,9 +20,12 @@ export class YamlDiscovery {
    * stores the items in cache, adds the items to the autocomplete list.
    */
   async parseYamlFiles(): Promise<void> {
+    // Matched at any depth: a theme or a package can carry its own
+    // node_modules. The space that used to sit after the comma made the second
+    // alternative " node_modules", which matched nothing.
     const files = await this.drupalWorkspace.findFiles(
       '**/*.yml',
-      '{vendor, node_modules}'
+      '**/{vendor,node_modules}/**'
     );
 
     // List of types that are not supported yet.

--- a/src/test/fixtures/drupal-site/node_modules/some_package/modules/bundled_module/bundled_module.info.yml
+++ b/src/test/fixtures/drupal-site/node_modules/some_package/modules/bundled_module/bundled_module.info.yml
@@ -1,0 +1,4 @@
+name: Bundled Module
+type: module
+description: 'Shipped inside an npm package and must never be suggested.'
+core_version_requirement: ^11

--- a/src/test/fixtures/drupal-site/vendor/drupal/vendored_package/modules/vendored_module/vendored_module.info.yml
+++ b/src/test/fixtures/drupal-site/vendor/drupal/vendored_package/modules/vendored_module/vendored_module.info.yml
@@ -1,0 +1,4 @@
+name: Vendored Module
+type: module
+description: 'Installed by Composer under vendor/ and must never be suggested.'
+core_version_requirement: ^11

--- a/src/test/integration/recipe-completion.test.ts
+++ b/src/test/integration/recipe-completion.test.ts
@@ -85,3 +85,26 @@ suite('Recipe completions', () => {
     );
   });
 });
+
+suite('Dependency directories', () => {
+  suiteSetup(async () => {
+    await activateExtension();
+  });
+
+  test('does not suggest modules from vendor or node_modules', async () => {
+    // Anchor on a suggestion that is expected, so the assertions below run
+    // against a populated cache rather than an empty one.
+    const labels = await completionLabelsAt(RECIPE, new vscode.Position(4, 8), [
+      'Recipe Test Module (MODULE)',
+    ]);
+
+    assert.ok(
+      !labels.includes('Vendored Module (MODULE)'),
+      'vendor/ must be excluded from the scan.'
+    );
+    assert.ok(
+      !labels.includes('Bundled Module (MODULE)'),
+      'node_modules/ must be excluded from the scan.'
+    );
+  });
+});


### PR DESCRIPTION
Closes #16.

The scan excluded `'{vendor, node_modules}'`. The space after the comma made the second alternative `" node_modules"`, which matches nothing, so every YAML file under `node_modules` was matched, type-detected, and any module-shaped one was read and cached.

On a Drupal project with a frontend build that is thousands of files on activation, and the modules it finds are npm packages that have nothing to do with the site.

Now `'**/{vendor,node_modules}/**'`, matched at any depth — a theme or a package can carry its own `node_modules`.

## Correcting the record

I flagged this in #14 as "vendor is not excluded either". That was wrong, and I checked before filing rather than after: `vendor` was always excluded correctly. Only the `node_modules` half was broken.

## Tests

The fixture gains a module-shaped info file under `vendor/` and another under `node_modules/`, and the integration suite asserts neither is ever suggested. The vendor half covers behaviour that already worked, so it stays working.

Before the fix, with both fixtures in place:

```
["NodeModules Module (MODULE)", "Recipe Test Module (MODULE)", "Recipe Test Theme (THEME)"]
AssertionError: node_modules/ must be excluded from the scan.
```

`.gitignore` re-includes `src/test/fixtures/drupal-site/node_modules/` so the fixture can be committed; the root `node_modules` stays ignored.

`npm run typecheck`, `npm run lint` (0 errors, same 18 pre-existing warnings) and `npm test` pass — 56 unit, 12 integration.
