### PR TITLE
#17 Give config suggestions an icon

### DIFF
--- a/src/test/integration/recipe-completion.test.ts
+++ b/src/test/integration/recipe-completion.test.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
-import { activateExtension, completionLabelsAt } from './helpers';
+import { activateExtension, completionLabelsAt, completionsAt } from './helpers';
 
 const RECIPE = 'recipes/recipe_under_test/recipe.yml';
 const ACTIONS = 'recipes/recipe_actions/recipe.yml';
@@ -40,6 +40,19 @@ suite('Recipe completions', () => {
     await completionLabelsAt(RECIPE, new vscode.Position(7, 11), [
       'recipe_test_module.settings (CONFIG)',
     ]);
+  });
+
+  test('config suggestions carry an icon', async () => {
+    await completionLabelsAt(RECIPE, new vscode.Position(7, 11), [
+      'recipe_test_module.settings (CONFIG)',
+    ]);
+
+    const items = await completionsAt(RECIPE, new vscode.Position(7, 11));
+    const config = items.find(
+      (item) => item.label === 'recipe_test_module.settings (CONFIG)'
+    );
+
+    assert.strictEqual(config?.kind, vscode.CompletionItemKind.Property);
   });
 
   test('grantPermissions resolves the ref to the permission list', async () => {

--- a/src/test/unit/icons.test.ts
+++ b/src/test/unit/icons.test.ts
@@ -9,6 +9,7 @@ describe('getIconKind', () => {
     ['profile', 18],
     ['content', 14],
     ['permission', 25],
+    ['config', 9],
     ['config_item', 5],
     ['config_contents', 13],
     ['not_implemented', 22],
@@ -17,7 +18,27 @@ describe('getIconKind', () => {
   });
 
   it('falls back to 0 for an unknown type', () => {
-    expect(getIconKind('config')).toBe(0);
+    expect(getIconKind('nonsense')).toBe(0);
     expect(getIconKind('')).toBe(0);
+  });
+
+  it('gives every symbol type processCompletionItem stores an icon', () => {
+    // processCompletionItem stores config entries as 'config' and
+    // 'config_item'; the callbacks add 'config_contents' and
+    // 'not_implemented'. None of them should reach the fallback.
+    for (const type of [
+      'recipe',
+      'module',
+      'theme',
+      'profile',
+      'content',
+      'permission',
+      'config',
+      'config_item',
+      'config_contents',
+      'not_implemented',
+    ]) {
+      expect(getIconKind(type), `${type} has no icon`).not.toBe(0);
+    }
   });
 });

--- a/src/utils/icons.ts
+++ b/src/utils/icons.ts
@@ -14,6 +14,7 @@ export function getIconKind(type: string): number {
     recipe: 16,
     module: 1,
     profile: 18,
+    config: 9,
     config_item: 5,
     config_contents: 13,
     theme: 15,


### PR DESCRIPTION
Closes #17.

`processCompletionItem()` stores config entries with the symbol type `config`, which `getIconKind()` had no entry for. The lookup fell through to `0` — `CompletionItemKind.Text` — so config names offered under `config/actions` rendered with a plain text icon while every other suggestion type had its own. The third call in the same function passes `config_item`, which *is* mapped, so the inconsistency sat inside one block.

Mapped `config` to `Property`, which reads as "a settings key" and doesn't collide with anything already in the map.

## Tests

- The unit test that pinned the old fallback (`getIconKind('config') === 0`) now asserts `9`, and the fallback case uses a genuinely unknown type.
- A new unit test walks every symbol type the code actually stores and fails if any of them reaches the fallback, so the next type added doesn't repeat this.
- An integration assertion checks the `kind` on a real config completion item, which is what catches it if the provider stops passing `symbolType` through.

Checked the integration assertion fails without the fix — removing the map entry gives `AssertionError: Expected values to be strictly equal` on `config suggestions carry an icon`.

`npm run typecheck`, `npm run lint` and `npm test` pass — 58 unit, 12 integration.
