### PR TITLE
#30 Drop the unused schemastore.org dependency

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,12 +19,14 @@ You may need to fork the repo for Json Schemas, please see these lines on packag
         ],
         "url": "https://raw.githubusercontent.com/SchemaStore/schemastore/refs/heads/master/src/schemas/json/drupal-recipe.json",
         "$fork": "https://raw.githubusercontent.com/marcelovani/schemastore/refs/heads/drupal-recipes/src/schemas/json/drupal-recipe.json",
-        "$local": "file:///Users/marcelo.vani/Development/Projects/Recipes/schemastore/src/schemas/json/drupal-recipe.json"
+        "$url": "file:///path/to/your/schemastore/src/schemas/json/drupal-recipe.json"
       }
     ],
 ```
 
-The key `url` is what is going to be used for the autocomplete of contextual items and validation. You can use the url from `$fork` or `$local` by copying the url onto the `url` item. Please don't commit this change, this is used only for development purposes.
+The key `url` is what is going to be used for the autocomplete of contextual items and validation. You can use the url from `$fork` or `$url` by copying the url onto the `url` item. Please don't commit this change, this is used only for development purposes.
+
+To work against a local schema, clone SchemaStore somewhere of your own and point `$url` at that checkout. It is not an npm dependency of this project, so nothing pulls it in for you.
 
 ### Running the tests
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
         "@vscode/vsce": "^3.9.2",
         "eslint": "^10.9.1",
         "globals": "^17.11.0",
-        "schemastore.org": "git+https://github.com/SchemaStore/schemastore.git",
         "ts-loader": "^9.5.1",
         "typescript": "^5.9.3",
         "vitest": "^4.1.11",
@@ -7511,15 +7510,6 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/schemastore.org": {
-      "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/SchemaStore/schemastore.git#fd3f06d9793a66597a4f97bc8e5590d9aa003d34",
-      "dev": true,
-      "license": "Apache 2.0",
-      "engines": {
-        "node": ">=18"
-      }
     },
     "node_modules/secretlint": {
       "version": "10.2.2",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
     "@vscode/vsce": "^3.9.2",
     "eslint": "^10.9.1",
     "globals": "^17.11.0",
-    "schemastore.org": "git+https://github.com/SchemaStore/schemastore.git",
     "ts-loader": "^9.5.1",
     "typescript": "^5.9.3",
     "vitest": "^4.1.11",


### PR DESCRIPTION
Closes #30.

`schemastore.org` was a git dependency on the entire SchemaStore repository:

```json
"schemastore.org": "git+https://github.com/SchemaStore/schemastore.git"
```

93MB on disk, cloned on every `npm ci` — which means all four CI jobs, every push, every Dependabot PR. Nothing imports it:

```
$ grep -rn "schemastore" src/ webpack.config.js eslint.config.mjs
(no matches)
```

The schema the extension actually uses is fetched by URL from the `yamlValidation` entry in `package.json`, so the repository on disk plays no part in the build, the tests or the packaged extension. Those URLs are untouched.

## CONTRIBUTING

The local-schema workflow described there pointed at a key it called `$local`, which `package.json` spells `$url`, with an absolute path from a home directory that isn't yours any more (`/Users/marcelo.vani/...`). Corrected, and it now says to clone SchemaStore separately — which is what that workflow needed all along, since the path was a sibling checkout rather than anything under `node_modules`.

## Checks

`npm run typecheck`, `npm run lint`, `npm test` (58 unit, 13 integration) and `vsce package` all pass. `npm ci` completes in under 4 seconds without the clone.

Dependabot's #27 bumps this dependency's commit and can be closed once this lands.
