### PR TITLE
#24 Stop packaging compiled tests and source maps

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -18,6 +18,10 @@ jobs:
       - run: npm run compile
       - name: Type check
         run: npm run typecheck
+      # .vscodeignore is easy to get wrong in a way nothing else notices until
+      # it is published.
+      - name: Check what would be packaged
+        run: npm run verify:package
 
   lint:
     name: Lint

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,3 +1,9 @@
+# vsce does not resolve this file the way .gitignore does. It splits the
+# patterns into ignores and negations, then keeps a file that matches no ignore
+# OR matches any negation — so a negation wins over every ignore in the file,
+# whatever the order. That means the negations below have to be narrow, because
+# nothing after them can take anything back.
+
 .vscode/**
 .vscode-test/**
 out/**
@@ -17,14 +23,12 @@ vsc-extension-quickstart.md
 *
 */**
 
-# Excludes
-!out/**/*
+# Excludes. out/ also holds the compiled tests and the source maps, so only the
+# webpack bundle is named here; it already has the sources and
+# suggestions-mapping.json compiled into it.
+!out/extension.js
 !assets/**/*
 !package.json
 !README.md
 !LICENSE.md
 !docs
-
-
-# Tests are compiled into out/ but must not ship in the extension.
-out/test/**

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -84,3 +84,14 @@ Then open a `recipe.yml` in that codebase and press `Ctrl+Space`.
 `.github/workflows/pr-checks.yml` runs build, lint, unit and integration as
 separate jobs. The integration job wraps the run in `xvfb-run` because the
 extension host needs a display and the runners are headless.
+
+## What gets published
+
+`npm run verify:package` asks vsce what the `.vsix` would contain and fails if
+the answer includes compiled tests, source maps, TypeScript sources or the test
+fixtures — or is missing `out/extension.js`. The build job runs it.
+
+`.vscodeignore` needs the care: vsce keeps a file that matches no ignore pattern
+**or** matches any negation, so a broad negation like `!out/**/*` overrides every
+ignore in the file regardless of order. The negations have to be narrow, because
+nothing after them can take anything back.

--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
     "test:unit": "vitest run",
     "test:unit:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "test:integration": "NODE_OPTIONS='--no-warnings' vscode-test"
+    "test:integration": "NODE_OPTIONS='--no-warnings' vscode-test",
+    "verify:package": "node scripts/check-package-contents.mjs"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.6",

--- a/scripts/check-package-contents.mjs
+++ b/scripts/check-package-contents.mjs
@@ -1,0 +1,52 @@
+/**
+ * Fails if the packaged extension would carry anything it should not.
+ *
+ * .vscodeignore is easy to get wrong: vsce keeps a file that matches no ignore
+ * pattern OR matches any negation, so a broad negation silently overrides every
+ * ignore in the file no matter where they sit. That is how the compiled tests
+ * and every source map ended up in a published build once already.
+ *
+ * This asserts the properties that matter rather than an exact file list, so
+ * adding a doc does not fail the build.
+ */
+import { listFiles } from '@vscode/vsce';
+
+const FORBIDDEN = [
+  { label: 'compiled tests', matches: (f) => f.startsWith('out/test/') },
+  { label: 'source maps', matches: (f) => f.endsWith('.map') },
+  { label: 'TypeScript sources', matches: (f) => f.endsWith('.ts') },
+  { label: 'the src directory', matches: (f) => f.startsWith('src/') },
+  { label: 'test fixtures', matches: (f) => f.includes('/fixtures/') },
+  { label: 'node_modules', matches: (f) => f.startsWith('node_modules/') },
+];
+
+const REQUIRED = ['package.json', 'out/extension.js', 'README.md'];
+
+const files = (await listFiles({ cwd: process.cwd() })).map((f) =>
+  f.split('\\').join('/')
+);
+
+const problems = [];
+
+for (const rule of FORBIDDEN) {
+  const hits = files.filter(rule.matches);
+
+  if (hits.length > 0) {
+    problems.push(`Would package ${rule.label}:\n  ${hits.join('\n  ')}`);
+  }
+}
+
+for (const required of REQUIRED) {
+  if (!files.includes(required)) {
+    problems.push(`Would not package ${required}, which the extension needs.`);
+  }
+}
+
+if (problems.length > 0) {
+  console.error(problems.join('\n\n'));
+  console.error(`\nFull list (${files.length} files):\n  ${files.join('\n  ')}`);
+  process.exit(1);
+}
+
+console.log(`Package contents look right (${files.length} files):`);
+console.log(files.map((f) => `  ${f}`).join('\n'));


### PR DESCRIPTION
Closes #24. This corrects a mistake in #14.

The published extension has been shipping the compiled integration tests and every source map.

## Why the rule I added in #14 did nothing

`vsce` does not resolve `.vscodeignore` the way `.gitignore` does. It splits the file into ignore patterns and negations, then keeps a file that matches **no** ignore **or** matches **any** negation. Order is irrelevant, so `!out/**/*` overrode every ignore pattern in the file — including the `out/test/**` line I added, and the `**/*.map` line that predates it.

I claimed on #14 that compiled tests no longer ship. That was wrong, and I only caught it because the vsix jumped from 11 to 40 files while I was checking something else on #18.

## Fix

A negation cannot be narrowed after the fact, so it has to be narrow to begin with. Only the webpack bundle needs to ship — it already has the sources and `suggestions-mapping.json` compiled into it:

```
!out/extension.js
```

40 files / 1.56MB → 8 files / 1.42MB:

```
package.json
README.md
LICENSE.md
out/extension.js
docs/testing.md
docs/icon.png
docs/drupal-recipes-autocomplete.gif
docs/development-quickstart.md
```

## Guard

`npm run verify:package` asks vsce what it would package and fails on compiled tests, source maps, TypeScript sources, fixtures or `node_modules`, and on `out/extension.js` being absent. It checks those properties rather than an exact file list, so adding a doc doesn't fail the build. Runs in the build job.

Confirmed it catches the original bug — putting `!out/**/*` back gives:

```
Would package compiled tests:
  out/test/integration/recipe-completion.test.js
  ...
Would package source maps:
  out/extension.js.map
  ...
```

`.vscodeignore` now carries a comment explaining the matching rule, since it is the kind of thing that gets "tidied" back into a broad negation.

## Note on source maps

`npm run package` builds with `--devtool hidden-source-map`, so the map is emitted but not referenced by the bundle. It is excluded here. If you would rather ship it so user stack traces are readable, say and I'll add `!out/extension.js.map` and relax that rule.

## Checks

`npm run typecheck`, `npm run lint`, `npm test` (58 unit, 13 integration) and `npm run verify:package` all pass.
