### PR TITLE
#6 Offer the config a module ships under config/import

### DIFF
--- a/src/base/drupal-workspace-yaml-discovery.ts
+++ b/src/base/drupal-workspace-yaml-discovery.ts
@@ -28,7 +28,10 @@ export class YamlDiscovery {
       '**/{vendor,node_modules}/**'
     );
 
-    // List of types that are not supported yet.
+    // Extension metadata files that are not config and have nothing to offer a
+    // recipe. `_action.yml` used to be here too, which excluded action config
+    // entities like system.action.node_delete_action.yml — config a recipe is
+    // meant to be able to import. See issue #6.
     const ignore: string[] = [
       '.libraries.yml',
       '.services.yml',
@@ -36,7 +39,6 @@ export class YamlDiscovery {
       '.breakpoints.yml',
       '.starterkit.yml',
       '.link_relation_types.yml',
-      '_action.yml',
       '.menu.yml',
       '/tests/',
       '/components/',
@@ -285,8 +287,20 @@ export class YamlDiscovery {
           );
 
           // Also add autocomplete for config/import/module_theme_name.
-          // @todo: This is not working correctly, we need to get the available configs in the module/config/install folder.
-          const name = configName.split('.')[0];
+          // A recipe imports config by naming the extension that ships it, not
+          // the prefix of the config itself: node's config/install holds
+          // system.action.node_delete_action.yml, which belongs under
+          // config/import/node. Take the name from the directory above
+          // config/install rather than from the config name.
+          const provider = filePath.match(
+            /\/([^/]+)\/config\/install\/[^/]+\.yml$/
+          );
+
+          if (provider === null) {
+            break;
+          }
+
+          const name = provider[1];
           this.storeCompletionItem(
             `config/import/${name}`,
             filePath,

--- a/src/test/fixtures/drupal-site/recipes/recipe_config_import/recipe.yml
+++ b/src/test/fixtures/drupal-site/recipes/recipe_config_import/recipe.yml
@@ -1,0 +1,6 @@
+name: 'Recipe Config Import'
+description: 'Exercises importing config by the module that provides it.'
+type: 'Site'
+config:
+  import:
+    recipe_test_module:

--- a/src/test/fixtures/drupal-site/web/modules/contrib/recipe_test_module/config/install/system.action.recipe_test_action.yml
+++ b/src/test/fixtures/drupal-site/web/modules/contrib/recipe_test_module/config/install/system.action.recipe_test_action.yml
@@ -1,0 +1,6 @@
+langcode: en
+status: true
+id: recipe_test_action
+label: 'Recipe test action'
+type: node
+plugin: node_delete_action

--- a/src/test/integration/recipe-completion.test.ts
+++ b/src/test/integration/recipe-completion.test.ts
@@ -5,6 +5,7 @@ import { activateExtension, completionLabelsAt, completionsAt } from './helpers'
 const RECIPE = 'recipes/recipe_under_test/recipe.yml';
 const ACTIONS = 'recipes/recipe_actions/recipe.yml';
 const EXISTING = 'recipes/recipe_existing_items/recipe.yml';
+const IMPORT = 'recipes/recipe_config_import/recipe.yml';
 
 suite('Recipe completions', () => {
   suiteSetup(async () => {
@@ -89,6 +90,15 @@ suite('Recipe completions', () => {
       !labels.includes('Recipe Test Module (MODULE)'),
       'recipe_test_module is already installed by this recipe.'
     );
+  });
+
+  test('config/import/<module> offers the config that module ships', async () => {
+    // node ships system.action.node_delete_action.yml in its own config/install,
+    // so a recipe importing node has to be offered it. Issue #6.
+    await completionLabelsAt(IMPORT, new vscode.Position(5, 24), [
+      'system.action.recipe_test_action (CONFIG)',
+      'recipe_test_module.settings (CONFIG)',
+    ]);
   });
 
   test('does not offer recipe suggestions outside a recipe file', async () => {

--- a/src/test/unit/yaml-discovery.test.ts
+++ b/src/test/unit/yaml-discovery.test.ts
@@ -33,6 +33,16 @@ describe('YamlDiscovery.detectFileType', () => {
     ).toBe(false);
   });
 
+  it('detects an action config entity as config', () => {
+    // These live in a module's config/install and are importable by a recipe.
+    // They were excluded by an `_action.yml` entry in the ignore list. Issue #6.
+    expect(
+      discovery.detectFileType(
+        '/site/web/core/modules/node/config/install/system.action.node_delete_action.yml'
+      )
+    ).toBe('config');
+  });
+
   it('returns false for a file that matches nothing', () => {
     expect(discovery.detectFileType('/site/web/sites/default/services.yml')).toBe(
       false
@@ -154,6 +164,34 @@ describe('YamlDiscovery.processCompletionItem', () => {
     );
 
     expect(labelsAt('global/permissions')).toEqual(['Administer foo (Permission)']);
+  });
+
+  it('keys config/import on the module that provides the config, not its prefix', () => {
+    // node's config/install holds system.action.node_delete_action.yml, which a
+    // recipe imports by naming the node module. Keying on the config prefix
+    // files it under system, where nothing looks for it. Issue #6.
+    discovery.processCompletionItem(
+      'config',
+      Uri.file(
+        '/site/web/modules/contrib/foo/config/install/system.action.foo_action.yml'
+      ),
+      { langcode: 'en' }
+    );
+
+    expect(labelsAt('config/import/foo')).toEqual([
+      'system.action.foo_action (CONFIG)',
+    ]);
+    expect(labelsAt('config/import/system')).toEqual([]);
+  });
+
+  it('still keys config/import on the module when the prefix matches it', () => {
+    discovery.processCompletionItem(
+      'config',
+      Uri.file('/site/web/modules/contrib/foo/config/install/foo.settings.yml'),
+      { langcode: 'en' }
+    );
+
+    expect(labelsAt('config/import/foo')).toEqual(['foo.settings (CONFIG)']);
   });
 
   it('stores nothing when the path does not match the expected shape', () => {


### PR DESCRIPTION
Closes #6.

Two separate causes, both needed fixing to get the behaviour the issue asks for.

## 1. config/import was keyed on the config prefix, not the module

```ts
// Also add autocomplete for config/import/module_theme_name.
// @todo: This is not working correctly, we need to get the available configs in the module/config/install folder.
const name = configName.split('.')[0];
```

A recipe imports config by naming **the extension that ships it**. `node` ships `system.action.node_delete_action.yml` in its own `config/install`, so it belongs under `config/import/node` — but splitting the config name filed it under `config/import/system`, where nothing looks for it. That is exactly the symptom in the issue: only `node.*` config was offered.

The name now comes from the directory above `config/install`.

## 2. The scan ignored the very files the issue lists

`parseYamlFiles` skipped anything whose path contains `_action.yml`:

```ts
const ignore: string[] = [
  '.libraries.yml',
  ...
  '_action.yml',
```

Which is `system.action.node_delete_action.yml`, `system.action.node_make_sticky_action.yml`, `system.action.node_promote_action.yml` — the exact files under "Expectation". So even with the keying fixed, they never reached the cache.

Removed. The rest of that list is extension metadata (`.libraries.yml`, `.services.yml`, `.breakpoints.yml`) that genuinely isn't config; `_action.yml` was the odd one out and matched on a substring rather than a suffix.

**Worth a look before merging:** this means a real site offers noticeably more config than before, because core ships a lot of `system.action.*` entities. That is what the issue asks for, but if the volume turns out to be unhelpful in practice, the second half is the part to revisit — the first half stands on its own.

## Tests

- Unit: `config/import` is keyed on the providing module, including the case where the config prefix and module name happen to match (so the fix isn't just moving the bug).
- Unit: an action config entity is detected as `config`.
- Integration: a new fixture recipe requests completions at `config: import: recipe_test_module:` and gets both `system.action.recipe_test_action` and `recipe_test_module.settings`.

Before the fix the integration test failed with exactly the issue's symptom:

```
Timed out waiting for ["system.action.recipe_test_action (CONFIG)","recipe_test_module.settings (CONFIG)"]
  Got: ["recipe_test_module.settings (CONFIG)"]
```

`npm run typecheck`, `npm run lint` (0 errors, same 18 pre-existing warnings) and `npm test` — 61 unit, 14 integration.

## Not fixed here

`config/optional/` is still not scanned — `detectFileType` calls it config, but `processCompletionItem` only matches `config/install`. Separate from what this issue describes, so I left it; say the word and I'll raise it.
