### PR TITLE
#4 Don't suggest what the recipe already has

### DIFF
--- a/src/providers/recipes-completion.ts
+++ b/src/providers/recipes-completion.ts
@@ -10,7 +10,12 @@ import {
 import DrupalWorkspaceProvider from '../base/drupal-workspace-provider';
 import suggestionsMapping from '../base/suggestions-mapping.json';
 import { functionMap } from '../base/suggestions-callbacks';
-import { getValueByPath, getPropertyPath } from '../utils/utils';
+import {
+  getValueByPath,
+  getPropertyPath,
+  getExistingValues,
+  getInsertedValue,
+} from '../utils/utils';
 import { YamlDiscovery } from '../base/drupal-workspace-yaml-discovery';
 import { cacheItem } from '../utils/cache';
 import { getIconKind } from '../utils/icons';
@@ -65,6 +70,12 @@ export default class RecipesCompletionProvider
     let propertyPath = getPropertyPath(document, position);
     console.debug(`Property path ${propertyPath}`);
 
+    // Where the cursor is in the recipe. propertyPath is about to be rewritten
+    // when the mapping points somewhere else, i.e. grantPermissions resolves to
+    // global/permissions, and what the recipe already holds lives under the
+    // path the author is actually typing at.
+    const documentPath = propertyPath;
+
     // Check if the property path matches any wildcard from suggestions-mapping.json.
     const value = getValueByPath(suggestionsMapping, propertyPath, '/');
     if (value !== false) {
@@ -97,6 +108,16 @@ export default class RecipesCompletionProvider
     cachedItems = cachedItems.filter((current, index, self) => {
       return index === self.findIndex((i) => i.item.completion.label === current.item.completion.label);
     });
+
+    // Don't offer what the recipe already has.
+    const existing = getExistingValues(document.getText(), documentPath);
+
+    if (existing.size > 0) {
+      cachedItems = cachedItems.filter(
+        (current) =>
+          !existing.has(getInsertedValue(current.item.completion.insertText))
+      );
+    }
 
     console.debug('Filtered options', cachedItems);
 

--- a/src/test/fixtures/drupal-site/recipes/recipe_existing_items/recipe.yml
+++ b/src/test/fixtures/drupal-site/recipes/recipe_existing_items/recipe.yml
@@ -1,0 +1,6 @@
+name: 'Recipe Existing Items'
+description: 'Already lists one of the modules the codebase offers.'
+type: 'Site'
+install:
+  - recipe_test_module
+  - 

--- a/src/test/integration/recipe-completion.test.ts
+++ b/src/test/integration/recipe-completion.test.ts
@@ -4,6 +4,7 @@ import { activateExtension, completionLabelsAt, completionsAt } from './helpers'
 
 const RECIPE = 'recipes/recipe_under_test/recipe.yml';
 const ACTIONS = 'recipes/recipe_actions/recipe.yml';
+const EXISTING = 'recipes/recipe_existing_items/recipe.yml';
 
 suite('Recipe completions', () => {
   suiteSetup(async () => {
@@ -73,6 +74,21 @@ suite('Recipe completions', () => {
     ]);
 
     assert.ok(labels.length > 0);
+  });
+
+  test('does not offer a module the recipe already installs', async () => {
+    // recipe_existing_items already lists recipe_test_module under install.
+    // Issue #4.
+    const labels = await completionLabelsAt(
+      EXISTING,
+      new vscode.Position(5, 4),
+      ['Recipe Test Theme (THEME)']
+    );
+
+    assert.ok(
+      !labels.includes('Recipe Test Module (MODULE)'),
+      'recipe_test_module is already installed by this recipe.'
+    );
   });
 
   test('does not offer recipe suggestions outside a recipe file', async () => {

--- a/src/test/unit/existing-values.test.ts
+++ b/src/test/unit/existing-values.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { getExistingValues, getInsertedValue } from '../../utils/utils';
+
+const RECIPE = [
+  "name: 'Test'",
+  'install:',
+  '  - node',
+  '  - text',
+  'config:',
+  '  import:',
+  '    node: "*"',
+  '  actions:',
+  '    user.role.editor:',
+  '      grantPermissions:',
+  "        - 'access content'",
+  "        - 'view own unpublished content'",
+].join('\n');
+
+describe('getExistingValues', () => {
+  it('reads the entries of a sequence', () => {
+    expect(getExistingValues(RECIPE, 'install')).toEqual(
+      new Set(['node', 'text'])
+    );
+  });
+
+  it('reads the keys of a mapping', () => {
+    expect(getExistingValues(RECIPE, 'config/import')).toEqual(
+      new Set(['node'])
+    );
+  });
+
+  it('walks a deep path', () => {
+    expect(
+      getExistingValues(
+        RECIPE,
+        'config/actions/user.role.editor/grantPermissions'
+      )
+    ).toEqual(new Set(['access content', 'view own unpublished content']));
+  });
+
+  it('returns nothing for a path the recipe does not have', () => {
+    expect(getExistingValues(RECIPE, 'recipes')).toEqual(new Set());
+    expect(getExistingValues(RECIPE, 'config/actions/user.role.admin')).toEqual(
+      new Set()
+    );
+  });
+
+  it('returns nothing for an empty path', () => {
+    expect(getExistingValues(RECIPE, '')).toEqual(new Set());
+  });
+
+  it('returns nothing rather than throwing on invalid yaml', () => {
+    // Half-typed recipes are invalid far more often than they are valid.
+    expect(getExistingValues('install:\n  - node\n :::bad', 'install')).toEqual(
+      new Set()
+    );
+  });
+
+  it('returns nothing when the path runs through a scalar', () => {
+    expect(getExistingValues(RECIPE, 'name/nope')).toEqual(new Set());
+  });
+});
+
+describe('getInsertedValue', () => {
+  it.each([
+    ['node\n- ', 'node'],
+    ['node:\n  - ', 'node'],
+    ["'access content'\n- ", 'access content'],
+    ['"access content"\n- ', 'access content'],
+    ['foo.settings:\n  ', 'foo.settings'],
+    ['bar.starterkit\n- ', 'bar.starterkit'],
+    ['plain', 'plain'],
+  ])('reduces %j to %j', (insertText, expected) => {
+    expect(getInsertedValue(insertText)).toBe(expected);
+  });
+});

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,3 +1,5 @@
+import { parse as parseYaml } from 'yaml';
+
 /**
  * The slice of TextDocument that getPropertyPath reads.
  *
@@ -190,4 +192,80 @@ export function getPropertyPath(
   } while (propertyCol > 0);
 
   return path;
+}
+
+/**
+ * The values already written under a property path in a recipe.
+ *
+ * Used to keep the completion list from offering something the recipe already
+ * has. The document is parsed as it stands, which mid-edit is often invalid
+ * YAML; that is not an error, it just means nothing is filtered.
+ *
+ * @param string text
+ *   The document contents.
+ * @param string path
+ *   The property path, separated by slashes i.e. config/import.
+ * @returns Set<string>
+ *   The values present at that path, or an empty set.
+ */
+export function getExistingValues(text: string, path: string): Set<string> {
+  const values = new Set<string>();
+
+  if (path === '') {
+    return values;
+  }
+
+  let parsed: unknown;
+
+  try {
+    parsed = parseYaml(text);
+  } catch {
+    // A recipe being typed into is invalid more often than not.
+    return values;
+  }
+
+  let node: unknown = parsed;
+
+  for (const segment of path.split('/')) {
+    if (node === null || typeof node !== 'object' || Array.isArray(node)) {
+      return values;
+    }
+
+    node = (node as Record<string, unknown>)[segment];
+  }
+
+  // A sequence holds its entries; a mapping holds them as keys.
+  if (Array.isArray(node)) {
+    for (const entry of node) {
+      if (typeof entry === 'string') {
+        values.add(entry);
+      }
+    }
+  } else if (node !== null && typeof node === 'object') {
+    for (const key of Object.keys(node)) {
+      values.add(key);
+    }
+  }
+
+  return values;
+}
+
+/**
+ * The value a completion would insert, without the snippet that follows it.
+ *
+ * Insert texts carry the continuation a recipe author wants next, i.e.
+ * `node\n- ` or `node:\n  - `, so only the first line identifies the item.
+ *
+ * @param string insertText
+ *   The completion's insert text.
+ * @returns string
+ *   The value it would add to the recipe.
+ */
+export function getInsertedValue(insertText: string): string {
+  const [first] = insertText.split('\n');
+
+  return first
+    .trim()
+    .replace(/:$/, '')
+    .replace(/^['"]|['"]$/g, '');
 }


### PR DESCRIPTION
Closes #4.

The provider parses the recipe as it stands and drops any suggestion whose value is already written under the path being completed. Sequences are matched on their entries, mappings on their keys, so one rule covers `install`, `recipes`, `config/import` and the permission lists.

## Two decisions worth checking

**The recipe is read at the path the cursor is in, not the path the suggestions come from.** The mapping rewrites `propertyPath` when it hits a `ref:` — `grantPermissions` resolves to `global/permissions` to fetch the list — but what the recipe *already grants* lives under `grantPermissions`. So the original path is captured before the rewrite and used for the lookup. Getting this backwards would have filtered against the wrong list and looked like it worked.

**Invalid YAML filters nothing rather than throwing.** A recipe with the cursor in it is half-typed and invalid most of the time, so `getExistingValues` catches the parse error and returns an empty set. The failure mode is "you see a suggestion you already have", not "completion breaks".

## Matching

`getInsertedValue` reduces a completion's insert text to the value it would actually add, since insert texts carry the continuation the author wants next:

| insert text | value |
| --- | --- |
| `node\n- ` | `node` |
| `node:\n  - ` | `node` |
| `'access content'\n- ` | `access content` |

Quotes are stripped because the permission list inserts them and the parsed YAML doesn't have them.

## Tests

14 unit tests over `getExistingValues` and `getInsertedValue` — sequences, mapping keys, deep paths, missing paths, a path running through a scalar, and invalid YAML.

Integration: a fixture recipe that already lists `recipe_test_module` under `install` is offered `Recipe Test Theme` but not `Recipe Test Module`.

Confirmed the integration test fails without the filter:

```
AssertionError: recipe_test_module is already installed by this recipe.
```

`npm run typecheck`, `npm run lint` (0 errors, same 18 pre-existing warnings) and `npm test` — 72 unit, 14 integration.

## One thing I deliberately did not do

Duplicate detection is exact-match on the value. A recipe that installs a module through a nested recipe still gets offered that module, because the extension would have to resolve and apply the nested recipe to know. That felt well beyond what the issue asks.
