### PR TITLE
Document the JSON schema the extension depends on

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,25 +8,12 @@ You can start by searching if there is already an issue in the (project page)[ht
 2. Push the changes to your fork
 3. Create a pull request and link to the issue
 
-You may need to fork the repo for Json Schemas, please see these lines on package.json
-
-```
-"yamlValidation": [
-      {
-        "fileMatch": [
-          "recipe.yml",
-          "recipe.yaml"
-        ],
-        "url": "https://raw.githubusercontent.com/SchemaStore/schemastore/refs/heads/master/src/schemas/json/drupal-recipe.json",
-        "$fork": "https://raw.githubusercontent.com/marcelovani/schemastore/refs/heads/drupal-recipes/src/schemas/json/drupal-recipe.json",
-        "$url": "file:///path/to/your/schemastore/src/schemas/json/drupal-recipe.json"
-      }
-    ],
-```
-
-The key `url` is what is going to be used for the autocomplete of contextual items and validation. You can use the url from `$fork` or `$url` by copying the url onto the `url` item. Please don't commit this change, this is used only for development purposes.
-
-To work against a local schema, clone SchemaStore somewhere of your own and point `$url` at that checkout. It is not an npm dependency of this project, so nothing pulls it in for you.
+The key names in `recipe.yml` come from a JSON schema on SchemaStore rather than
+from this codebase, so a missing key is often a change to make there instead of here.
+[docs/json-schema.md](docs/json-schema.md) explains how the two halves fit together,
+how to develop against a fork of the schema, and the history of the
+[pull request](https://github.com/SchemaStore/schemastore/pull/4187) that the extension
+was built on.
 
 ### Running the tests
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ VS Code extension that provides autocomplete for Drupal Recipes
 ## Features
 
 - Provides autocomplete suggestions for Drupal recipes.
-- Provides validation for recipe.yml.
+- Provides validation for recipe.yml, via the [Drupal recipe JSON schema](https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/drupal-recipe.json)
+  on SchemaStore — see [docs/json-schema.md](./docs/json-schema.md).
 - See the list of [supported Config actions](https://github.com/marcelovani/drupal-recipes-autocomplete-vscode/wiki/Properties)
 
 ## Instructions

--- a/docs/json-schema.md
+++ b/docs/json-schema.md
@@ -1,0 +1,90 @@
+# The JSON schema
+
+Half of what this extension appears to do is not done by this extension. The
+key names in `recipe.yml`, and the validation that flags a typo, come from a
+JSON schema hosted by [SchemaStore](https://www.schemastore.org) and fetched by
+the `redhat.vscode-yaml` extension.
+
+Knowing which half a gap belongs to saves a lot of time.
+
+| | Comes from | Lives in |
+| --- | --- | --- |
+| Key and action **names**, validation, hover text | `drupal-recipe.json` | [SchemaStore](https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/drupal-recipe.json) |
+| **Values** read from your Drupal codebase — module names, config names, permissions | this extension | `src/base/suggestions-mapping.json` and `src/base/suggestions-callbacks.ts` |
+
+An action that is missing entirely is usually a schema problem. An action whose
+name completes but whose values do not is usually ours.
+
+## How it is wired
+
+`package.json` declares the schema against the recipe filenames:
+
+```json
+"yamlValidation": [
+  {
+    "fileMatch": ["recipe.yml", "recipe.yaml"],
+    "url": "https://raw.githubusercontent.com/SchemaStore/schemastore/refs/heads/master/src/schemas/json/drupal-recipe.json",
+    "$fork": "https://raw.githubusercontent.com/marcelovani/schemastore/refs/heads/drupal-recipes/src/schemas/json/drupal-recipe.json",
+    "$url": "file:///path/to/your/schemastore/src/schemas/json/drupal-recipe.json"
+  }
+]
+```
+
+`url` is the one that is used. `$fork` and `$url` are parking spaces: copy either
+over `url` to develop against a change before it is merged, and don't commit
+that. `$url` expects a clone of SchemaStore of your own — it is not an npm
+dependency of this project and nothing installs it for you.
+
+## History
+
+The schema was not created for this extension; it already existed on
+SchemaStore, which is why the first release could complete the basic properties
+without scanning anything.
+
+- [SchemaStore#4186](https://github.com/SchemaStore/schemastore/issues/4186) —
+  the issue asking for the schema to cover more of the recipe format.
+- [SchemaStore#4187](https://github.com/SchemaStore/schemastore/pull/4187) —
+  merged 4 November 2024. Extended the schema from the config action list,
+  fixed the required properties, and gave the default snippet a description so
+  new files offer "New Recipe" rather than the filename. This is what took the
+  extension from completing roughly a fifth of the static items to most of them.
+- [Drupal #3475786](https://www.drupal.org/project/distributions_recipes/issues/3475786)
+  — the standing proposal to make the schema the structure that Drupal's own
+  recipe documentation and validation are generated from, rather than a
+  hand-written copy of them.
+
+Contributing to SchemaStore: their
+[CONTRIBUTING.md](https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md).
+Their CI validates schemas with Ajv, and every schema has a test file — for this
+one, `src/test/drupal-recipe/drupal-recipe.yml`. A change that adds properties
+should extend that test too, as #4187 did.
+
+## Keeping it current
+
+The schema is hand-maintained from Drupal's recipe documentation, and both drift
+behind core. Two things follow from that:
+
+**Check the schema against core, not against the docs.** The docs can lag as
+easily as the schema. `scripts/extract-config-actions.php` generates the list
+from a core checkout, and `src/base/core-config-actions.json` is its committed
+output. See [tracking-drupal-recipes.md](./tracking-drupal-recipes.md).
+
+**Some actions cannot be in a static schema at all.**
+`PermissionsPerBundleDeriver` generates `grantPermissionsForEach<BundleEntityType>`
+from the entity types installed on the site, and `AddModerationDeriver` does the
+same for `add<PluralBundleEntityType>`. Those names differ per site. The schema
+can only carry the ones core happens to ship, which is the case for scanning the
+codebase — see issue #8.
+
+Likewise `EntityMethodDeriver` pluralises every `#[ActionMethod]` name unless
+told not to, so `setFilterConfig` implies `setFilterConfigs`. The schema needs
+both spellings, as it already has for `grantPermission(s)`.
+
+## Where the schema currently stands
+
+Checked against `drupal/drupal` `11.x`. `input`, `extra` and `config.strict` are
+absent from the schema, along with seventeen config actions. The schema sets
+`additionalProperties: true`, so none of these are reported as *invalid* — they
+simply get no completion and no validation.
+
+Tracked in issue #39.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -41,6 +41,10 @@ fills in shortly after activation. `completionLabelsAt()` in
 `src/test/integration/helpers.ts` polls until the expected suggestions appear
 rather than sleeping for a fixed period.
 
+The `yamlValidation` assertion checks the contribution is registered, not that the
+schema itself is correct — that lives on SchemaStore and has its own tests. See
+[json-schema.md](./json-schema.md).
+
 ## Fixture workspace
 
 `src/test/fixtures/drupal-site/` is a Drupal-shaped tree, a few kilobytes in

--- a/docs/tracking-drupal-recipes.md
+++ b/docs/tracking-drupal-recipes.md
@@ -21,6 +21,8 @@ codebase in the workspace. Only actions whose *values* are worth completing from
 the codebase need an entry.
 
 So "action X is missing" splits into two different jobs, in two repositories.
+[json-schema.md](./json-schema.md) covers the schema half — how it is wired, how to
+develop against a fork, and how to contribute a change upstream.
 
 ## Source first, documentation second
 


### PR DESCRIPTION
Half of what the extension appears to do is done by a schema hosted on SchemaStore and fetched by `redhat.vscode-yaml`. Nothing in the repository said so, which makes a missing action look like a bug here when it is usually a change to make there.

New `docs/json-schema.md` covers:

- **Which half is which.** Key and action *names*, validation and hover text come from the schema; *values* read out of your Drupal codebase come from `suggestions-mapping.json` and the callbacks. An action that is missing entirely is usually a schema problem; an action whose name completes but whose values don't is usually ours.
- **The `url` / `$fork` / `$url` block** in `package.json` and how it is meant to be used — including that `$url` expects a clone of SchemaStore of your own, since nothing installs one.
- **The history**: [SchemaStore#4186](https://github.com/SchemaStore/schemastore/issues/4186), the [#4187](https://github.com/SchemaStore/schemastore/pull/4187) pull request that took the extension from completing roughly a fifth of the static items to most of them, and the standing [Drupal proposal #3475786](https://www.drupal.org/project/distributions_recipes/issues/3475786) to generate the recipe documentation from the schema.
- **How to contribute upstream** — their CONTRIBUTING, the Ajv validation in their CI, and the test file every schema has.
- **The two reasons a static schema can never be complete**: `EntityMethodDeriver` pluralises action names automatically, and `PermissionsPerBundleDeriver` / `AddModerationDeriver` generate names from the entity types installed on a given site. That is the case for #8, stated where someone will find it.

## Also

`CONTRIBUTING.md` kept its own copy of the `yamlValidation` block, complete with an absolute path from a home directory and a `$local` key that `package.json` spells `$url`. Replaced with a pointer to the doc, so there is one description of this instead of two that disagree.

`README.md`, `docs/testing.md` and `docs/tracking-drupal-recipes.md` cross-link rather than repeat.

Docs only, no code change. `npm run typecheck`, `npm run lint` and `npm test` (80 unit, 14 integration) pass, and `npm run verify:package` confirms the new doc ships with the extension as the others do.

Raised alongside #39, which is the actual schema work.
