### PR TITLE
Stop Dependabot reopening two deliberate decisions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,18 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    ignore:
+      # ts-loader cannot load TypeScript 7: the webpack build dies with
+      # "Cannot read properties of undefined (reading 'fileExists')". Revisit
+      # when ts-loader supports it. See #18.
+      - dependency-name: typescript
+        update-types:
+          - version-update:semver-major
+      # Pinned to the floor that engines.vscode advertises, so the compiler
+      # enforces the compatibility the extension claims. Letting this float
+      # is what #18 fixed; raising it is a deliberate decision about which
+      # VS Code versions to drop, not a dependency bump.
+      - dependency-name: "@types/vscode"
     groups:
       # Routine bumps arrive as one PR that can be merged on the strength of CI.
       npm-minor-and-patch:


### PR DESCRIPTION
Stops #31 and #32 coming back every week.

## `typescript` — major updates only

`ts-loader` cannot load TypeScript 7. The webpack build dies before it compiles anything:

```
TypeError: Cannot read properties of undefined (reading 'fileExists')
    at findConfigFile (node_modules/ts-loader/dist/config.js:105:30)
```

That is what makes #31 red on Build, Lint and Unit tests. TS 7 also removes `moduleResolution: node10`; switching to `node16` type checks fine, so the config is the easy half and the loader is the blocker.

Minor and patch updates are still allowed, so 5.9.x keeps moving.

## `@types/vscode` — ignored outright

`engines.vscode` is `^1.95.0`, and #28 pinned the types to `~1.95.0` so the compiler enforces the compatibility the extension advertises. #32 raises them back to 1.134.0.

Worth being clear about why that PR is green: it passes **because** nothing enforces the floor once the types float. Green CI there is the bug, not evidence against it. It matters for #12/#19 too, since the editors that lag furthest behind are exactly the ones we want to support.

Raising the floor is a decision about which VS Code versions to drop, not a dependency bump, so it should not arrive as one.

## Note

`ignore` is per-ecosystem in Dependabot's schema, so these sit under the npm entry only; the github-actions entry is untouched. Config-only change — validated the YAML parses and the two groups are intact.
