### PR TITLE
Release 1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+## 1.1.2 (2026-08-28)
+
+ Bug fixes
+  - Fixed node_modules being scanned for suggestions, which was slow on projects with a frontend build and offered npm packages as if they were Drupal modules (#16)
+  - Fixed config/import not offering the config a module actually ships, such as system.action.node_delete_action.yml under node (#6)
+  - Fixed config suggestions showing no icon (#17)
+  - Stopped the published extension carrying its own test files and source maps, cutting the download from 40 files to 8 (#24)
+
+ New functionalities
+ - Suggestions no longer include items the recipe already has, for modules, recipes, config imports and permissions alike (#4)
+
+ Under the hood
+ - Added unit and integration test suites, and fixed the test runner, which could not launch current VS Code at all (#5)
+ - Added a generated list of the config actions Drupal core exposes, with a test that fails when core adds one we have not classified (#29)
+ - Pinned @types/vscode to the version engines.vscode advertises, so the compiler enforces the compatibility the extension claims (#18)
+ - Updated dependencies, taking npm audit from 26 findings to 4, and enabled Dependabot (#18, #15)
+ - Removed a 93MB dependency that nothing imported (#30)
+ - Documented the JSON schema the extension depends on, and how to keep up with Drupal's config actions
+
 ## 1.1.1 (2024-11-13)
 
  Bug fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drupal-recipes-autocomplete-vscode",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drupal-recipes-autocomplete-vscode",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.6.0"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "icon": "docs/icon.png",
   "publisher": "marcelovani",
   "author": "Marcelo Vani",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "license": "MIT",
   "engines": {
     "vscode": "^1.95.0"


### PR DESCRIPTION
Prepares 1.1.2 for publishing. Version bump, lockfile and changelog only — no code.

1.1.2 rather than 1.2.0: bug fixes and packaging, with #4 the only thing a user would call a feature, and it is a refinement of existing behaviour rather than a new capability.

## Already done outside this PR

`v1.1.0` and `v1.1.1` are now tagged. They were published to the marketplace on 13 November 2024 and never tagged, so there was no commit in git matching what people had installed. Both are annotated tags on the commit that set the version in `package.json`, which is how `v1.0.7` and earlier were tagged:

```
v1.1.0 -> a79a64d 2024-11-13
v1.1.1 -> 60c7f6f 2024-11-13
```

## Still to do after this merges

1. Tag `v1.1.2` on the merge commit.
2. Create the GitHub release — there are none at all in the repo's history, for any version.
3. Publish: `npm run package && npm run publish`.

On (3): `"publish": "vsce publish ${version}"` does not do what it looks like. npm does not expand `${version}`; the shell expands it to empty, so it reduces to `vsce publish`, which publishes whatever is in `package.json`. That works, but only by accident. Left alone here since we agreed to discuss the release tooling separately, along with the dead `release-it` config.

## Checks

`npm run typecheck`, `npm run lint` (0 errors, same 18 pre-existing warnings), `npm test` — 83 unit, 15 integration — and `npm run verify:package` all pass.

Packaged the candidate to confirm what would ship:

```
DONE  Packaged: v112.vsix (11 files, 1.42 MB)
```

Against 1.1.1's 42 files and 1.65MB, with the test suite and source maps no longer inside.
