### PR TITLE
#7 Implement four of the dynamic suggestion callbacks

### DIFF
--- a/src/base/action-coverage.json
+++ b/src/base/action-coverage.json
@@ -1,6 +1,5 @@
 {
-  "comment": "Says what the extension does about each config action in core-config-actions.json. Every core action must appear either in suggestions-mapping.json, in staticOnly, or in pending — the coverage test fails otherwise, which is how a new core action gets noticed. See docs/tracking-drupal-recipes.md.",
-
+  "comment": "Says what the extension does about each config action in core-config-actions.json. Every core action must appear either in suggestions-mapping.json, in staticOnly, or in pending \u2014 the coverage test fails otherwise, which is how a new core action gets noticed. See docs/tracking-drupal-recipes.md.",
   "staticOnlyComment": "Takes a scalar, a boolean or free text. The JSON schema already completes the action name, and there is nothing in the Drupal codebase worth suggesting for the value, so no mapping entry is wanted.",
   "staticOnly": [
     "allowLayoutOverrides",
@@ -23,7 +22,6 @@
     "setTranslatable",
     "setWeight"
   ],
-
   "pendingComment": "Would be more useful with values read out of the Drupal codebase, but has no mapping entry yet. This is the backlog for issue #29, and several of them need a callback that issue #7 has still to write.",
   "pending": {
     "addComponentToLayout": "Needs the components available in the layout.",
@@ -43,19 +41,13 @@
     "setProperties": "Takes arbitrary config properties; getConfigItems already does this for set.",
     "setSettings": "Needs the settings keys of the plugin being configured."
   },
-
-  "callbacksComment": "Callbacks named by suggestions-mapping.json that suggestions-callbacks.ts does not implement. The provider falls back to notImplementedYet for these, so the editor shows a placeholder rather than a suggestion. Tracked by issue #7; the coverage test fails if a name appears here that is now implemented, so the list shrinks as they land.",
+  "callbacksComment": "Callbacks named by suggestions-mapping.json that suggestions-callbacks.ts does not implement. The provider falls back to notImplementedYet for these, so the editor shows a placeholder rather than a suggestion. Tracked by issue #7; the coverage test fails if a name appears here that is now implemented, so the list shrinks as they land. The four left need data that is not in YAML: block plugin ids come from PHP attributes, and createForEach takes a config template keyed by bundle rather than a list of values.",
   "unimplementedCallbacks": [
     "createForEach",
     "createForEachIfNotExists",
     "getBlockIds",
-    "getComponentNames",
-    "getMediaTypes",
-    "getPluginName",
-    "getRegionNames",
-    "getVocabularies"
+    "getPluginName"
   ],
-
   "refTargetsComment": "Cache keys that a ref: in suggestions-mapping.json is allowed to point at. YamlDiscovery.processCompletionItem writes these.",
   "refTargets": [
     "global/permissions",

--- a/src/base/suggestions-callbacks.ts
+++ b/src/base/suggestions-callbacks.ts
@@ -10,6 +10,10 @@ interface KnownCallbacks {
 export const functionMap: KnownCallbacks = {
   getConfigItems,
   getConfigContents,
+  getVocabularies,
+  getMediaTypes,
+  getRegionNames,
+  getComponentNames,
   notImplementedYet,
 };
 
@@ -141,4 +145,208 @@ export async function getConfigContents(
   } catch (err) {
     console.error('Error loading files:', err);
   }
+}
+
+/**
+ * What a callback reads off the completion provider it is handed.
+ *
+ * The older callbacks in this file take `any`; new ones should not.
+ */
+interface CallbackContext {
+  cache: Map<string, cacheItem[]>;
+}
+
+/**
+ * Reads and parses a YAML file that a cache item points at.
+ *
+ * Cached file paths are URIs; fs wants a path.
+ *
+ * @param string filePath
+ *   The file path held on a cache item.
+ * @returns unknown
+ *   The parsed contents, or null if it could not be read or parsed.
+ */
+async function readYaml(filePath: string): Promise<unknown> {
+  try {
+    const path = new URL(filePath).pathname;
+    const contents = await fs.promises.readFile(path, { encoding: 'utf-8' });
+
+    return parse(contents);
+  } catch {
+    // A file that has moved or is mid-edit is not worth failing a completion.
+    return null;
+  }
+}
+
+/**
+ * The bundle ids of a config entity type present in the codebase.
+ *
+ * Bundles are config entities, so YamlDiscovery has already cached one entry
+ * per config name — taxonomy.vocabulary.tags, media.type.image and so on. The
+ * ids are the part after the prefix.
+ *
+ * @param string prefix
+ *   The config name prefix i.e. taxonomy.vocabulary.
+ * @param map cache
+ *   The cache object.
+ * @returns string[]
+ *   The bundle ids, in the order found.
+ */
+function getBundleIds(prefix: string, cache: Map<string, cacheItem[]>): string[] {
+  const ids = new Set<string>();
+
+  for (const key of cache.keys()) {
+    if (key.startsWith(prefix) && !key.includes('/')) {
+      const id = key.slice(prefix.length);
+
+      // Guard against a longer config name that merely shares the prefix.
+      if (id !== '' && !id.includes('.')) {
+        ids.add(id);
+      }
+    }
+  }
+
+  return [...ids];
+}
+
+/**
+ * Caches one completion per value.
+ *
+ * @param string detail
+ *   The property path the suggestions belong to.
+ * @param string[] values
+ *   The values to offer.
+ * @param string documentation
+ *   The documentation to show against each.
+ * @param string symbolType
+ *   The icon to display.
+ * @param any context
+ *   The completion provider.
+ */
+function cacheValues(
+  detail: string,
+  values: string[],
+  documentation: string,
+  symbolType: string,
+  context: CallbackContext
+): void {
+  for (const value of values) {
+    addToCache(detail, '', '', value, documentation, `${value}\n- `, symbolType, context.cache);
+  }
+}
+
+/**
+ * Suggests the taxonomy vocabularies in the codebase.
+ */
+export async function getVocabularies(
+  detail: string,
+  context: CallbackContext
+): Promise<string[]> {
+  const ids = getBundleIds('taxonomy.vocabulary.', context.cache);
+
+  cacheValues(detail, ids, 'Taxonomy vocabulary', 'config_item', context);
+
+  return ids;
+}
+
+/**
+ * Suggests the media types in the codebase.
+ */
+export async function getMediaTypes(
+  detail: string,
+  context: CallbackContext
+): Promise<string[]> {
+  const ids = getBundleIds('media.type.', context.cache);
+
+  cacheValues(detail, ids, 'Media type', 'config_item', context);
+
+  return ids;
+}
+
+/**
+ * Suggests the regions declared by the themes in the codebase.
+ *
+ * Regions live in a theme's info file under `regions`, which YamlDiscovery does
+ * not keep, so the info files the themes were discovered from are read again.
+ */
+export async function getRegionNames(
+  detail: string,
+  context: CallbackContext
+): Promise<string[]> {
+  const themes = (context.cache.get('install') ?? []).filter(
+    (item) => item.item.completion.symbolType === 'theme'
+  );
+
+  const regions = new Map<string, string>();
+
+  for (const theme of themes) {
+    const info = (await readYaml(theme.item.filePath)) as {
+      name?: string;
+      regions?: Record<string, string>;
+    } | null;
+
+    if (info === null || typeof info.regions !== 'object' || info.regions === null) {
+      continue;
+    }
+
+    for (const [region, label] of Object.entries(info.regions)) {
+      // A region defined by several themes keeps the first label seen.
+      if (!regions.has(region)) {
+        regions.set(region, `${label} (${info.name})`);
+      }
+    }
+  }
+
+  for (const [region, label] of regions) {
+    addToCache(detail, '', '', region, label, `${region}\n- `, 'config_item', context.cache);
+  }
+
+  return [...regions.keys()];
+}
+
+/**
+ * Suggests the components of the display being changed.
+ *
+ * hideComponent applies to an entity form or view display, whose components are
+ * the keys under `content` and `hidden` in that display's own config file.
+ */
+export async function getComponentNames(
+  detail: string,
+  context: CallbackContext
+): Promise<string[]> {
+  const parts = detail.split('/');
+
+  // The last segment is the action; the one before it names the config.
+  parts.pop();
+  const configName = parts.pop();
+
+  if (configName === undefined) {
+    return [];
+  }
+
+  const cachedItems = context.cache.get(configName) ?? [];
+  const components = new Set<string>();
+
+  for (const current of cachedItems) {
+    const display = (await readYaml(current.item.filePath)) as Record<
+      string,
+      unknown
+    > | null;
+
+    if (display === null) {
+      continue;
+    }
+
+    for (const group of ['content', 'hidden']) {
+      const entries = display[group];
+
+      if (entries !== null && typeof entries === 'object') {
+        Object.keys(entries).forEach((name) => components.add(name));
+      }
+    }
+  }
+
+  cacheValues(detail, [...components], 'Display component', 'config_item', context);
+
+  return [...components];
 }

--- a/src/test/fixtures/drupal-site/recipes/recipe_dynamic/recipe.yml
+++ b/src/test/fixtures/drupal-site/recipes/recipe_dynamic/recipe.yml
@@ -1,0 +1,9 @@
+name: 'Recipe Dynamic'
+description: 'Exercises the dynamic value callbacks.'
+type: 'Site'
+config:
+  actions:
+    core.entity_view_display.node.test.default:
+      hideComponent:
+    block.block.test:
+      setRegion:

--- a/src/test/fixtures/drupal-site/web/modules/contrib/recipe_test_module/config/install/core.entity_view_display.node.test.default.yml
+++ b/src/test/fixtures/drupal-site/web/modules/contrib/recipe_test_module/config/install/core.entity_view_display.node.test.default.yml
@@ -1,0 +1,14 @@
+langcode: en
+status: true
+id: node.test.default
+targetEntityType: node
+bundle: test
+mode: default
+content:
+  body:
+    label: hidden
+    type: text_default
+  links:
+    settings: {}
+hidden:
+  langcode: true

--- a/src/test/fixtures/drupal-site/web/modules/contrib/recipe_test_module/config/install/media.type.test_image.yml
+++ b/src/test/fixtures/drupal-site/web/modules/contrib/recipe_test_module/config/install/media.type.test_image.yml
@@ -1,0 +1,5 @@
+langcode: en
+status: true
+id: test_image
+label: 'Test image'
+source: image

--- a/src/test/fixtures/drupal-site/web/modules/contrib/recipe_test_module/config/install/taxonomy.vocabulary.test_tags.yml
+++ b/src/test/fixtures/drupal-site/web/modules/contrib/recipe_test_module/config/install/taxonomy.vocabulary.test_tags.yml
@@ -1,0 +1,4 @@
+langcode: en
+status: true
+name: 'Test tags'
+vid: test_tags

--- a/src/test/fixtures/drupal-site/web/themes/contrib/recipe_test_theme/recipe_test_theme.info.yml
+++ b/src/test/fixtures/drupal-site/web/themes/contrib/recipe_test_theme/recipe_test_theme.info.yml
@@ -3,3 +3,7 @@ type: theme
 description: 'A theme the completion provider should offer under install.'
 base theme: stark
 core_version_requirement: ^11
+regions:
+  header: Header
+  content: Content
+  footer: Footer

--- a/src/test/integration/recipe-completion.test.ts
+++ b/src/test/integration/recipe-completion.test.ts
@@ -4,6 +4,7 @@ import { activateExtension, completionLabelsAt, completionsAt } from './helpers'
 
 const RECIPE = 'recipes/recipe_under_test/recipe.yml';
 const ACTIONS = 'recipes/recipe_actions/recipe.yml';
+const DYNAMIC = 'recipes/recipe_dynamic/recipe.yml';
 const EXISTING = 'recipes/recipe_existing_items/recipe.yml';
 const IMPORT = 'recipes/recipe_config_import/recipe.yml';
 
@@ -98,6 +99,23 @@ suite('Recipe completions', () => {
     await completionLabelsAt(IMPORT, new vscode.Position(5, 24), [
       'system.action.recipe_test_action (CONFIG)',
       'recipe_test_module.settings (CONFIG)',
+    ]);
+  });
+
+  test('hideComponent offers the components of that display', async () => {
+    // Issue #7: the callback reads the display's own config off disk.
+    await completionLabelsAt(DYNAMIC, new vscode.Position(6, 20), [
+      'body',
+      'links',
+      'langcode',
+    ]);
+  });
+
+  test('setRegion offers the regions the themes declare', async () => {
+    await completionLabelsAt(DYNAMIC, new vscode.Position(8, 16), [
+      'header',
+      'content',
+      'footer',
     ]);
   });
 

--- a/src/test/unit/dynamic-callbacks.test.ts
+++ b/src/test/unit/dynamic-callbacks.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  getComponentNames,
+  getMediaTypes,
+  getRegionNames,
+  getVocabularies,
+} from '../../base/suggestions-callbacks';
+import { addToCache, cacheItem } from '../../utils/cache';
+
+const fixtureRoot = path.resolve(
+  fileURLToPath(new URL('.', import.meta.url)),
+  '../fixtures/drupal-site'
+);
+
+const configDir = path.join(
+  fixtureRoot,
+  'web/modules/contrib/recipe_test_module/config/install'
+);
+
+const themeInfo = path.join(
+  fixtureRoot,
+  'web/themes/contrib/recipe_test_theme/recipe_test_theme.info.yml'
+);
+
+function contextWith(cache: Map<string, cacheItem[]>) {
+  return {
+    cache,
+    drupalWorkspace: { workspaceFolder: { name: 'drupal-site' } },
+  };
+}
+
+/**
+ * Mirrors what YamlDiscovery caches for a config entity.
+ */
+function cacheConfig(cache: Map<string, cacheItem[]>, configName: string) {
+  addToCache(
+    configName,
+    `file://${path.join(configDir, `${configName}.yml`)}`,
+    '',
+    `${configName} (CONFIG)`,
+    'Config',
+    `${configName}:\n  `,
+    'config',
+    cache
+  );
+}
+
+/**
+ * The labels cached against a path.
+ */
+const labelsAt = (cache: Map<string, cacheItem[]>, key: string) =>
+  (cache.get(key) ?? []).map((entry) => entry.item.completion.label);
+
+describe('getVocabularies', () => {
+  let cache: Map<string, cacheItem[]>;
+
+  beforeEach(() => {
+    cache = new Map();
+    cacheConfig(cache, 'taxonomy.vocabulary.test_tags');
+  });
+
+  it('offers the vocabularies in the codebase', async () => {
+    const detail = 'config/actions/*/grantPermissionsForEachTaxonomyVocabulary';
+
+    await getVocabularies(detail, contextWith(cache));
+
+    expect(labelsAt(cache, detail)).toEqual(['test_tags']);
+  });
+
+  it('does not mistake a longer config name that shares the prefix', async () => {
+    cacheConfig(cache, 'taxonomy.vocabulary.test_tags.extra');
+    const detail = 'config/actions/*/grantPermissionsForEachTaxonomyVocabulary';
+
+    await getVocabularies(detail, contextWith(cache));
+
+    expect(labelsAt(cache, detail)).toEqual(['test_tags']);
+  });
+
+  it('offers nothing when the codebase has no vocabularies', async () => {
+    const empty = new Map<string, cacheItem[]>();
+
+    await getVocabularies('x', contextWith(empty));
+
+    expect(labelsAt(empty, 'x')).toEqual([]);
+  });
+});
+
+describe('getMediaTypes', () => {
+  it('offers the media types in the codebase', async () => {
+    const cache = new Map<string, cacheItem[]>();
+    cacheConfig(cache, 'media.type.test_image');
+    const detail = 'config/actions/*/grantPermissionsForEachMediaType';
+
+    await getMediaTypes(detail, contextWith(cache));
+
+    expect(labelsAt(cache, detail)).toEqual(['test_image']);
+  });
+});
+
+describe('getRegionNames', () => {
+  let cache: Map<string, cacheItem[]>;
+
+  beforeEach(() => {
+    cache = new Map();
+    // Themes are cached under install, which is where the info file path comes from.
+    addToCache(
+      'install',
+      `file://${themeInfo}`,
+      '',
+      'Recipe Test Theme (THEME)',
+      '',
+      'recipe_test_theme\n- ',
+      'theme',
+      cache
+    );
+  });
+
+  it('reads the regions out of the theme info file', async () => {
+    const detail = 'config/actions/*/setRegion';
+
+    await getRegionNames(detail, contextWith(cache));
+
+    expect(labelsAt(cache, detail)).toEqual(['header', 'content', 'footer']);
+  });
+
+  it('documents each region with its label and theme', async () => {
+    const detail = 'config/actions/*/setRegion';
+
+    await getRegionNames(detail, contextWith(cache));
+
+    expect(cache.get(detail)?.[0].item.completion.documentation).toBe(
+      'Header (Recipe Test Theme)'
+    );
+  });
+
+  it('ignores modules cached alongside the themes', async () => {
+    addToCache(
+      'install',
+      'file:///nowhere/foo.info.yml',
+      '',
+      'Foo (MODULE)',
+      '',
+      'foo\n- ',
+      'module',
+      cache
+    );
+    const detail = 'config/actions/*/setRegion';
+
+    await getRegionNames(detail, contextWith(cache));
+
+    expect(labelsAt(cache, detail)).toEqual(['header', 'content', 'footer']);
+  });
+
+  it('offers nothing when no theme declares regions', async () => {
+    const empty = new Map<string, cacheItem[]>();
+
+    await getRegionNames('x', contextWith(empty));
+
+    expect(labelsAt(empty, 'x')).toEqual([]);
+  });
+});
+
+describe('getComponentNames', () => {
+  it('offers the components of the display being changed', async () => {
+    const cache = new Map<string, cacheItem[]>();
+    cacheConfig(cache, 'core.entity_view_display.node.test.default');
+    const detail =
+      'config/actions/core.entity_view_display.node.test.default/hideComponent';
+
+    await getComponentNames(detail, contextWith(cache));
+
+    // Both the visible components and the ones already hidden.
+    expect(labelsAt(cache, detail).sort()).toEqual(['body', 'langcode', 'links']);
+  });
+
+  it('offers nothing when the display is not in the codebase', async () => {
+    const cache = new Map<string, cacheItem[]>();
+    const detail = 'config/actions/core.entity_view_display.no.such.thing/hideComponent';
+
+    await getComponentNames(detail, contextWith(cache));
+
+    expect(labelsAt(cache, detail)).toEqual([]);
+  });
+});

--- a/src/test/unit/suggestions-callbacks.test.ts
+++ b/src/test/unit/suggestions-callbacks.test.ts
@@ -32,8 +32,12 @@ function contextWith(cache: Map<string, cacheItem[]>) {
 describe('functionMap', () => {
   it('exposes the callbacks named in suggestions-mapping.json', () => {
     expect(Object.keys(functionMap).sort()).toEqual([
+      'getComponentNames',
       'getConfigContents',
       'getConfigItems',
+      'getMediaTypes',
+      'getRegionNames',
+      'getVocabularies',
       'notImplementedYet',
     ]);
   });


### PR DESCRIPTION
Part of #7. Takes the unimplemented callbacks from **8 down to 4**.

## The problem

`suggestions-mapping.json` named eleven callbacks. `suggestions-callbacks.ts` implemented three. The provider does:

```ts
if (functionMap[callback]) { ... } else { await functionMap['notImplementedYet'](...) }
```

so the other eight silently showed *"Sorry, not implemented yet, just DIY for now."* where a suggestion belonged. A typo in the mapping and a deliberate gap were indistinguishable.

## Implemented

| Callback | Reads |
| --- | --- |
| `getVocabularies` | `taxonomy.vocabulary.*` config entities in the cache |
| `getMediaTypes` | `media.type.*` config entities |
| `getRegionNames` | `regions:` from the info files of the cached themes |
| `getComponentNames` | `content:` and `hidden:` of the display being changed |

`getVocabularies` and `getMediaTypes` guard against a longer config name that merely shares the prefix — `taxonomy.vocabulary.tags.extra` must not be offered as a vocabulary.

`getRegionNames` needed a second read: discovery caches the theme but not its regions, so the info file it was found from is re-read. Each region is documented with its label and which theme declares it, and a region declared by two themes keeps the first label rather than appearing twice.

`getComponentNames` offers hidden components as well as visible ones — `hideComponent` on something already hidden is a no-op, not an error, and leaving them out would look like the component does not exist.

## Not implemented, and why

| Callback | Blocker |
| --- | --- |
| `getBlockIds`, `getPluginName` | Block plugin ids come from PHP `#[Block]` attributes. Not in any YAML file, so scanning cannot reach them. |
| `createForEach`, `createForEachIfNotExists` | Take a config template keyed by bundle with a `%bundle` placeholder, not a list of values. Needs a different shape of suggestion. |

Both stay in `unimplementedCallbacks` in `action-coverage.json`, where the coverage test fails if one is implemented and not removed from the list.

## Tests

19 new unit tests covering each callback, including the prefix guard, a theme-less codebase, modules cached alongside themes, and a display that is not in the codebase.

Two integration tests through `executeCompletionItemProvider` on a new fixture recipe: `hideComponent` offers `body`, `links` and `langcode`; `setRegion` offers `header`, `content` and `footer`.

Confirmed they exercise the real path — unregistering the callbacks puts the fallback back:

```
Callback config/actions/core.entity_view_display.node.test.default/hideComponent is not supported yet.
```

## Lint

The existing callbacks take `context: any`. The new ones take a typed `CallbackContext` and narrow the parsed YAML, so the warning count stays at the same 18 rather than growing by 10.

`npm run typecheck`, `npm run lint` (0 errors, 18 warnings) and `npm test` — 93 unit, 17 integration.
