### PR TITLE
Document releasing, and drop the tooling the pipeline replaced

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,42 +43,14 @@ You can also debug and test it by hand.
 
 ### Releasing
 
-Releases are published by `.github/workflows/publish.yml` when a version tag is
-pushed. It runs the whole suite, checks the tag matches `package.json`, then
-publishes to the Visual Studio Marketplace **and** Open VSX, and creates the
-GitHub release with the changelog entry attached.
+A release is a pushed tag: `.github/workflows/publish.yml` runs the suite, checks
+the tag matches `package.json`, and publishes to the Visual Studio Marketplace and
+Open VSX before creating the GitHub release.
 
-1. Add the entry to `CHANGELOG.md` and set the matching version in `package.json`.
-2. Merge that to `main`.
-3. Tag and push:
-
-   ```bash
-   git tag -a v1.2.3 -m v1.2.3 && git push origin v1.2.3
-   ```
-
-Two repository secrets are needed:
-
-| Secret | For | Where from |
-| --- | --- | --- |
-| `VSCE_PAT` | Visual Studio Marketplace | Azure DevOps personal access token, Marketplace > Manage |
-| `OVSX_PAT` | Open VSX | open-vsx.org, after claiming the `marcelovani` namespace |
-
-Open VSX is what the VS Code forks install from — Windsurf, Devin, VSCodium,
-code-server — since they cannot use the Microsoft marketplace. Publishing there
-fails soft, so a missing token holds up nobody else's install.
-
-Use the workflow's manual run (`workflow_dispatch`) with **dry run** left on to
-build and check a release without publishing anything.
-
-### Packaging and deploying by hand
-Add entry in the Changelog with version number/date and list of changes.
-Update the version in package.json to match the version in the Changelog.
-
-To package you need to using:
 ```bash
-npm run package
-npm run publish
+git tag -a v1.2.3 -m v1.2.3 && git push origin v1.2.3
 ```
 
-See more details in the (VS Code documentation)[https://code.visualstudio.com/api/working-with-extensions/publishing-extension]
-
+[docs/releasing.md](docs/releasing.md) has the whole of it, including how to create
+the `VSCE_PAT` and `OVSX_PAT` secrets — both have a step that is easy to get wrong
+and gives an unhelpful error — and how to do a dry run that publishes nothing.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ VS Code extension that provides autocomplete for Drupal Recipes
 Contributions are more than welcome! Read [CONTRIBUTING.md](./CONTRIBUTING.md) for more information,
 and [docs/testing.md](./docs/testing.md) for how to run the tests.
 [docs/tracking-drupal-recipes.md](./docs/tracking-drupal-recipes.md) covers how support for new
-Drupal config actions gets tracked and ported.
+Drupal config actions gets tracked and ported, and [docs/releasing.md](./docs/releasing.md)
+covers publishing.
 
 ## Repository
 https://github.com/marcelovani/drupal-recipes-autocomplete-vscode

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,124 @@
+# Releasing
+
+A release is a pushed tag. `.github/workflows/publish.yml` does the rest: runs
+the suite, checks the tag against `package.json`, builds the `.vsix` once, and
+publishes that same file to both registries before creating the GitHub release.
+
+## Making a release
+
+1. Add the entry to `CHANGELOG.md`, and set the matching version in
+   `package.json`. The heading must be `## <version> (<date>)` — the workflow
+   reads the release notes from it by matching the version.
+2. Merge that to `main`.
+3. Tag and push:
+
+   ```bash
+   git tag -a v1.2.3 -m v1.2.3
+   git push origin v1.2.3
+   ```
+
+The tag must match `package.json` or the run stops before publishing anything:
+
+```
+::error::tag v1.2.3 does not match package.json version 1.2.2
+```
+
+That check exists because `vsce` publishes whatever version `package.json`
+holds and treats the tag as a label. Without it, tagging a version you forgot
+to bump quietly republishes the previous one.
+
+## Two registries
+
+| Registry | Installed by | Secret |
+| --- | --- | --- |
+| Visual Studio Marketplace | VS Code itself | `VSCE_PAT` |
+| [Open VSX](https://open-vsx.org) | Windsurf, Devin, VSCodium, code-server, Gitpod | `OVSX_PAT` |
+
+The forks are contractually barred from the Microsoft marketplace, so an
+extension that is only on one of these does not exist for them. Both are
+published from the same run, from the same built file, so they cannot drift.
+
+The Open VSX step is `continue-on-error`: a missing namespace or an expired
+token there should not hold up the release everybody else installs from. Check
+the run afterwards rather than assuming both succeeded.
+
+## Creating `VSCE_PAT`
+
+The marketplace authenticates through Azure DevOps, which is not obvious.
+
+1. Sign in to [dev.azure.com](https://dev.azure.com/) with the **same Microsoft
+   account that owns the `marcelovani` publisher**. A different account will
+   authenticate fine and then fail with "you do not have permission to publish".
+2. If you have no organisation, create one. The name is irrelevant; it exists
+   only so Azure will issue you a token.
+3. Top right, user settings → **Personal access tokens** → **New Token**.
+4. Set **Organization** to **All accessible organizations**. This is the step
+   people get wrong — a token scoped to one organisation fails against the
+   marketplace with a 401 that does not explain itself.
+5. Set **Scopes** to **Custom defined**, then find **Marketplace** and tick
+   **Manage**.
+6. Create it and copy the token. It is shown once.
+
+```bash
+gh secret set VSCE_PAT --repo marcelovani/drupal-recipes-autocomplete-vscode
+```
+
+Tokens expire — a year is the maximum. When a release fails on the marketplace
+step with a 401, an expired token is the first thing to check.
+
+## Creating `OVSX_PAT`
+
+1. Log in to [open-vsx.org](https://open-vsx.org) with GitHub.
+2. **Accept the Publisher Agreement**, under your profile. Publishing is refused
+   until you have, and the error does not say so clearly.
+3. Profile → **Access Tokens** → generate one, and copy it.
+4. Claim the namespace, once:
+
+   ```bash
+   npx ovsx create-namespace marcelovani -p <token>
+   ```
+
+```bash
+gh secret set OVSX_PAT --repo marcelovani/drupal-recipes-autocomplete-vscode
+```
+
+## Trying it without publishing
+
+The workflow has a manual trigger with a dry run option, on by default:
+
+> Actions → Publish → Run workflow
+
+It builds, runs the tests, checks what would be packaged, and uploads the
+`.vsix` as an artifact — publishing nothing. Worth doing after any change to
+the workflow, and to get an installable build for testing.
+
+## Publishing by hand
+
+The pipeline is the way to publish. Doing it by hand skips the tests, the
+package check and the tag/version check, and leaves no GitHub release — so it
+is for the case where the pipeline itself is broken.
+
+```bash
+npm ci
+npm test
+npm run verify:package
+npx vsce package --out extension.vsix
+npx vsce publish --packagePath extension.vsix   # needs VSCE_PAT in the environment
+npx ovsx publish extension.vsix                 # needs OVSX_PAT
+```
+
+Then tag the commit you published from, so git still matches what people have
+installed.
+
+There used to be an `npm run publish` script reading `vsce publish ${version}`.
+npm does not expand `${version}`; the shell expanded it to nothing, so it
+published whatever was in `package.json` — right by accident. It has been
+removed rather than fixed, because a one-word command that skips every check is
+the wrong thing to have lying around.
+
+## History
+
+`v1.1.0` and `v1.1.1` were published in November 2024 and never tagged; the tags
+were backfilled later against the commits that set those versions. Before
+`v1.1.2` there were no GitHub releases at all. Tagging is what triggers a
+release now, so that particular drift cannot recur.

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "compile": "webpack",
     "watch": "webpack --watch",
     "package": "webpack --mode production --devtool hidden-source-map",
-    "publish": "vsce publish ${version}",
     "compile-tests": "tsc -p . --outDir out",
     "watch-tests": "tsc -p . -w --outDir out",
     "pretest": "npm run compile-tests && npm run compile && npm run lint",
@@ -99,20 +98,5 @@
   },
   "extensionDependencies": [
     "redhat.vscode-yaml"
-  ],
-  "release-it": {
-    "plugins": {
-      "@release-it-plugins/lerna-changelog": {
-        "infile": "CHANGELOG.md",
-        "launchEditor": false
-      }
-    },
-    "git": {
-      "tagName": "v${version}"
-    },
-    "github": {
-      "release": true,
-      "tokenRef": "GITHUB_AUTH"
-    }
-  }
+  ]
 }


### PR DESCRIPTION
Answers "is this documented in our code at all?" — it was, but only as a two-row table saying *where* the tokens come from, not *how*. Both have a step that is easy to get wrong and reports it badly, which is exactly the part worth writing down.

Also does the dead-weight removal from #35.

## New `docs/releasing.md`

The whole process, plus the two gotchas:

- **`VSCE_PAT` must be scoped to "All accessible organizations".** A token scoped to a single organisation authenticates fine and then fails against the marketplace with a 401 that does not explain itself. It also has to be issued from the Microsoft account that owns the `marcelovani` publisher, or you get "you do not have permission to publish" from a token that looks valid.
- **Open VSX refuses to publish until the Publisher Agreement is accepted**, and the error does not say that is the problem.

Also covers the dry run, what the tag/version check is protecting against, and why publishing by hand is a last resort rather than a shortcut.

## Removed

**The `release-it` block in `package.json`.** It configured `@release-it-plugins/lerna-changelog`, a tag format and GitHub release creation. `release-it` has never been a dependency of this project, so it described a process that did not exist — the most misleading kind of config, since it reads as if someone could run it.

**The `publish` script**, which read:

```json
"publish": "vsce publish ${version}"
```

npm does not expand `${version}`; the shell expands it to nothing, so it reduced to `vsce publish` and published whatever `package.json` held. Correct by accident. Now that the pipeline runs the tests, the package check and the tag/version check, a one-word command that skips all three is a footgun rather than a convenience.

The equivalent manual commands are in the doc, for the case where the pipeline itself is broken — with the checks spelled out rather than skipped.

Checked nothing else referenced either: no workflow, script or doc calls `npm run publish`.

## Checks

`npm run typecheck`, `npm run lint` (0 errors, same 18 warnings), `npm test` (93 unit, 17 integration) and `npm run verify:package` all pass.
