### PR TITLE
Note that the new PAT is hidden by the default filter

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -81,6 +81,13 @@ Then:
 gh secret set VSCE_PAT --repo marcelovani/drupal-recipes-autocomplete-vscode
 ```
 
+The token then appears to vanish. The list on that page has an **Access scope**
+filter that defaults to a single organization, and the token you just made is a
+global one — so the default view is the one view that cannot show it. Set the
+filter to **All accessible organizations** and it is there. Nothing has gone
+wrong; the only scope that works for publishing is the one the default filter
+hides.
+
 Tokens expire — a year is the maximum. When a release fails on the marketplace
 step with a 401, an expired token is the first thing to check.
 


### PR DESCRIPTION
Cost us ten minutes today, so worth recording.

After creating the token, the list showed **"You do not have any personal access tokens yet."** The token was there the whole time — the list has an **Access scope** filter that defaults to a single organization, and the token has to be scoped to *all accessible organizations* for vsce to accept it.

So the default view is the one view that cannot show the token you just made:

| Token name | Scope | Status | Expires |
| --- | --- | --- | --- |
| Github actions for publishing on marketplace | Marketplace (Manage) | Active | 28/08/2027 |

Visible only once the filter is switched to **All accessible organizations**.

Docs only, one paragraph in `docs/releasing.md` next to the `gh secret set` line, which is where you are standing when it happens.