### PR TITLE
Fail the release when Open VSX does not publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -70,12 +70,20 @@ jobs:
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
 
-      # Never blocks the marketplace publish: a missing Open VSX namespace or
-      # token should not hold up the release everyone else installs from.
+      # Fails the run rather than passing quietly. continue-on-error was worse
+      # than useless here: it sets the step's conclusion to success while the
+      # outcome is a failure, so the 1.1.2 release showed a green tick for a
+      # step that had died on a missing token, and the only evidence was in the
+      # logs. A release that reached one registry and not the other must be
+      # obvious.
       - name: Publish to Open VSX
         if: startsWith(github.ref, 'refs/tags/') && !inputs.dry_run
-        continue-on-error: true
-        run: npx ovsx publish drupal-recipes-autocomplete-vscode.vsix
+        run: |
+          if [ -z "$OVSX_PAT" ]; then
+            echo "::error::OVSX_PAT is not set, so Open VSX was not published. See docs/releasing.md."
+            exit 1
+          fi
+          npx ovsx publish drupal-recipes-autocomplete-vscode.vsix
         env:
           OVSX_PAT: ${{ secrets.OVSX_PAT }}
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -107,6 +107,22 @@ step with a 401, an expired token is the first thing to check.
 gh secret set OVSX_PAT --repo marcelovani/drupal-recipes-autocomplete-vscode
 ```
 
+## A version is published once
+
+Every release is a new version and a new tag. A tag that has been pushed is
+never moved or re-pushed, and a version that has been published is never
+republished.
+
+That matters because the two registries can end up out of step — 1.1.2 reached
+the marketplace and not Open VSX, because there was no token for the second one
+at the time. The fix for that is not to republish the version; it is to fix
+whatever was wrong and let the next version carry it to both. The marketplace
+refuses a duplicate version anyway, so a re-pushed tag would fail on that step
+before reaching Open VSX.
+
+A registry can therefore be one version behind for a while. That is a normal
+state, not a broken one.
+
 ## Trying it without publishing
 
 The workflow has a manual trigger with a dry run option, on by default:


### PR DESCRIPTION
Reduced to just the `continue-on-error` fix, per the policy that tags are only ever new — the republish machinery is dropped.

## The bug

`continue-on-error: true` on the Open VSX step sets the step's *conclusion* to success while its *outcome* is failure. So the 1.1.2 run reported this:

```
success: Publish to Open VSX
```

for a step that had actually done this:

```
OVSX_PAT: 
? Personal Access Token for namespace 'marcelovani':
❌  User force closed the prompt with 0 null
##[error]Process completed with exit code 1.
```

A release that reached one registry and not the other looked identical to one that reached both. I only found it by reading the logs, which is not a thing anyone should have to do on a green run.

It now fails the run, and names the missing token rather than making you dig.

## The policy it assumes

`docs/releasing.md` now states it plainly: a version is published once, a pushed tag is never moved or re-pushed, and a registry that missed a release is caught up by the **next** version rather than by republishing the old one.

Worth writing down because the marketplace refuses duplicate versions anyway — so a re-pushed tag would die on that step before ever reaching Open VSX. The workaround does not exist, and now nobody has to rediscover that.

It also means a registry can sit one version behind for a while. That is a normal state, not a broken one.

## Checks

Workflow YAML validated. The dry-run path is untouched and was proven green earlier today; the failure path is by inspection, since it needs a missing secret to exercise.