### PR TITLE
Say who owns the code, and what ships inside the bundle

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -31,4 +31,5 @@ vsc-extension-quickstart.md
 !package.json
 !README.md
 !LICENSE.md
+!THIRD-PARTY-NOTICES.md
 !docs

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2022 Stanislav Romanov <kaermorchen@gmail.com>
+Copyright (c) 2024-2026 Marcelo Vani
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -36,3 +36,15 @@ https://github.com/marcelovani/drupal-recipes-autocomplete-vscode
 - Support Default Content
 - Do not show autocomplete items that are already in the Recipe
 - Fix Lint warnings
+
+## License
+
+MIT — see [LICENSE.md](./LICENSE.md). Free to use, modify and redistribute,
+provided as is and without warranty of any kind.
+
+This extension began as part of the
+[Drupal extension for VS Code](https://github.com/kaermorchen/vscode-drupal),
+also MIT, whose copyright notice is kept alongside ours.
+[THIRD-PARTY-NOTICES.md](./THIRD-PARTY-NOTICES.md) covers the code bundled into
+the published extension.
+

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -1,0 +1,52 @@
+# Third-party notices
+
+The published extension is a single bundled file, `out/extension.js`, built by
+webpack. Code from the projects below is compiled into it, so their notices
+travel with it as their licences require.
+
+This file lists what ships. Everything else in `devDependencies` is used only to
+build and test, and is not distributed.
+
+---
+
+## yaml
+
+Parses and serialises the YAML in `recipe.yml` and in the Drupal codebase being
+scanned.
+
+- <https://github.com/eemeli/yaml>
+- ISC licence
+
+```
+Copyright Eemeli Aro <eemeli@gmail.com>
+
+Permission to use, copy, modify, and/or distribute this software for any purpose
+with or without fee is hereby granted, provided that the above copyright notice
+and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+THIS SOFTWARE.
+```
+
+---
+
+## Drupal extension for VS Code
+
+This extension started life as a branch of
+[kaermorchen/vscode-drupal](https://github.com/kaermorchen/vscode-drupal), and
+parts of its structure remain. That project is MIT licensed, and its copyright
+notice is kept in [LICENSE.md](./LICENSE.md) alongside ours, as MIT requires.
+
+---
+
+## Not bundled
+
+The Drupal recipe JSON schema is fetched over HTTP at runtime by
+`redhat.vscode-yaml`; it is not part of this extension. It lives at
+[SchemaStore](https://github.com/SchemaStore/schemastore) under that project's
+own terms. See [docs/json-schema.md](./docs/json-schema.md).


### PR DESCRIPTION
Three small gaps found while reading the Open VSX Publisher Agreement, whose §8c has you warranting you hold the rights to everything you publish.

**Nothing changes legally for anyone using the extension.** MIT already said free, modifiable, as is, no warranty. This makes the attribution correct.

## 1. Your name was not on your own copyright

`LICENSE.md` credited only the upstream author:

```
Copyright (c) 2022 Stanislav Romanov <kaermorchen@gmail.com>
```

inherited when this began as a branch of [kaermorchen/vscode-drupal](https://github.com/kaermorchen/vscode-drupal). That line is **required** to stay — MIT says the notice travels with the code, and upstream is confirmed MIT, so nothing was wrong. But nearly all the current code is not covered by it. A second line is added beside it rather than replacing it:

```
Copyright (c) 2022 Stanislav Romanov <kaermorchen@gmail.com>
Copyright (c) 2024-2026 Marcelo Vani
```

## 2. README never mentioned the licence

It said "Contributions are more than welcome" without saying under what terms. Now has a short License section — MIT, as is, no warranty — crediting the upstream project.

## 3. The bundled `yaml` package had no notice

The published extension is one webpacked file. `yaml@2.9.0` is compiled into it (92 references in `out/extension.js`), and it is **ISC**, which like MIT requires its copyright notice to travel with the code. Only your `LICENSE.md` was shipping.

`THIRD-PARTY-NOTICES.md` now carries it verbatim and ships in the vsix:

```
package.json
THIRD-PARTY-NOTICES.md
README.md
LICENSE.md
out/extension.js
docs/...
```

It also records what is **not** bundled — the JSON schema is fetched at run time by `redhat.vscode-yaml` and is not part of this extension, which is worth stating so nobody assumes SchemaStore's terms apply to the vsix.

## Deliberately not done

No separate terms-of-use, no contributor licence agreement, no "as is" prose in the README. MIT already covers all of it, and adding parallel wording invites argument about which text governs.

## Checks

`npm run typecheck`, `npm run lint` (0 errors, same 18 warnings), `npm test` (93 unit, 17 integration) and `npm run verify:package` all pass.
