### PR TITLE
Release 1.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 1.1.3 (2026-08-29)
+
+ New functionalities
+ - The extension is now published to Open VSX as well as the Visual Studio Marketplace, so it can be installed in VS Code forks such as Windsurf, Devin, VSCodium and code-server (#19)
+
+ Under the hood
+ - Added THIRD-PARTY-NOTICES.md carrying the notice for the yaml package bundled into the extension, and a copyright line for the work since this project began as a branch of kaermorchen/vscode-drupal, so the attribution matches what actually ships
+ - README now states the licence, which it never did
+ - A release that reaches one registry and not the other fails visibly instead of reporting success
+
 ## 1.1.2 (2026-08-28)
 
  Bug fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drupal-recipes-autocomplete-vscode",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drupal-recipes-autocomplete-vscode",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.6.0"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "icon": "docs/icon.png",
   "publisher": "marcelovani",
   "author": "Marcelo Vani",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "license": "MIT",
   "engines": {
     "vscode": "^1.95.0"


### PR DESCRIPTION
Version, lockfile and changelog. No code.

The point of this release is **Open VSX** — 1.1.2 reached the marketplace only, because there was no token at the time. Since a published version is never republished, catching Open VSX up means a new version, and this is it.

## What is actually in it

```
.github/workflows/publish.yml   Open VSX failure is no longer silent
.vscodeignore                   ships the notices file
LICENSE.md                      copyright line for work since the fork
README.md                       states the licence
THIRD-PARTY-NOTICES.md          new
docs/releasing.md               the one-version-one-publish policy
```

## Correction I made while writing the changelog

I first credited the #7 dynamic callbacks to this release. They are not in it — #44 merged before `v1.1.2` was tagged, so they went out in 1.1.2. The changelog says so correctly now.

Nothing a user will notice changes in 1.1.3, beyond it existing on a second registry.

## Checks

`npm run typecheck`, `npm run lint` (0 errors, same 18 warnings), `npm test` (93 unit, 17 integration) and `npm run verify:package` pass. The package is 12 files, now including `THIRD-PARTY-NOTICES.md`.

After merge I will tag `v1.1.3`, which publishes to both registries and creates the release.