### PR TITLE
#8 Discover the config actions this codebase actually has

### DIFF
--- a/docs/tracking-drupal-recipes.md
+++ b/docs/tracking-drupal-recipes.md
@@ -86,6 +86,46 @@ Change records carry a worked YAML example and say which version introduced the
 action. They are the best single source for a specific action, just not for
 knowing the full set.
 
+## What the extension discovers for itself
+
+The generated list covers core, and the schema covers what a static file can.
+Neither can cover two things, so `src/base/config-action-discovery.ts` works
+them out from the codebase that is open:
+
+**Actions that depend on the site.** `PermissionsPerBundleDeriver` turns every
+bundle entity type into `grantPermissionsForEach<Bundle>`, so
+`grantPermissionsForEachMediaType` exists on a site with media and not on one
+without. These are derived from the config entities the YAML scan already
+found — a `media.type.*` in the codebase means the action exists.
+
+**Actions a contrib or custom module declares.** Only that module's PHP says so.
+`PhpDiscovery` reads `#[ConfigAction]` and `#[ActionMethod]` out of
+`**/{modules,themes,profiles}/**/src/**/*.php`, skipping `core` because core's
+actions already ship, and skipping any file that does not mention an attribute
+at all.
+
+Attributes are matched rather than parsed. A real PHP parser would be more
+robust, but `web-tree-sitter` plus the PHP grammar costs roughly 3MB shipped
+against a 0.32MB bundle, which is a poor trade for two attribute shapes.
+
+That is only defensible while the matching agrees with the PHP extractor, so
+there is a check:
+
+```bash
+npm run compile-tests
+node scripts/cross-check-discovery.mjs /path/to/drupal-core src/base/core-config-actions.json
+```
+
+Give it the same core commit the JSON was generated from, recorded in its
+`generatedFrom` field — a different version reports actions that merely moved
+out of core. Against `11.x` at `f0cc91d7ec9` it finds no false positives, and
+misses only the eight deriver-produced names such as `create` and
+`placeBlockInDefaultTheme`, which a deriver decides at runtime and which are
+folded into `core-config-actions.json` by hand.
+
+If that ever stops holding, switching to tree-sitter is the answer, and this
+script is how you would know.
+
 ## Recording the decision
 
 Every action in `core-config-actions.json` must be accounted for in

--- a/scripts/cross-check-discovery.mjs
+++ b/scripts/cross-check-discovery.mjs
@@ -1,0 +1,59 @@
+/**
+ * Checks the runtime discovery against the PHP extractor, on real core.
+ *
+ * The extension finds config actions by matching attributes in PHP rather than
+ * parsing it. That is cheap and adds no dependency, but it is only defensible
+ * while it agrees with scripts/extract-config-actions.php, which is the same
+ * patterns applied by PHP itself. This runs both over a core checkout and
+ * reports the difference.
+ *
+ * Usage, after npm run compile-tests:
+ *   node scripts/cross-check-discovery.mjs /path/to/drupal-core src/base/core-config-actions.json
+ *
+ * Give it the same core commit the JSON was generated from, recorded in its
+ * generatedFrom field. Comparing against a different version reports actions
+ * that simply moved out of core, which is not a discovery failure.
+ *
+ * Expect no false positives, and misses only of deriver-produced names such as
+ * create or placeBlockInDefaultTheme: a deriver decides those at runtime, so
+ * they are folded into core-config-actions.json by hand instead.
+ */
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { actionsInPhp } from '../out/base/config-action-discovery.js';
+
+const root = process.argv[2];
+const expected = new Set(JSON.parse(readFileSync(process.argv[3], 'utf8')).actions.map((a) => a.name));
+
+const found = new Set();
+let scanned = 0;
+
+function walk(dir) {
+  for (const entry of readdirSync(dir)) {
+    const p = join(dir, entry);
+    let st;
+    try { st = statSync(p); } catch { continue; }
+    if (st.isDirectory()) {
+      if (entry === 'tests' || entry === 'node_modules' || entry === 'vendor') continue;
+      walk(p);
+    } else if (entry.endsWith('.php')) {
+      const src = readFileSync(p, 'utf8');
+      if (!src.includes('ConfigAction') && !src.includes('ActionMethod')) continue;
+      scanned++;
+      for (const a of actionsInPhp(src, 'core')) found.add(a.name);
+    }
+  }
+}
+
+walk(join(root, 'core'));
+
+// entity_method is the deriver base and is never written in a recipe.
+found.delete('entity_method');
+
+const missed = [...expected].filter((n) => !found.has(n));
+const extra = [...found].filter((n) => !expected.has(n));
+
+console.log(`scanned ${scanned} php files with an attribute`);
+console.log(`php extractor found ${expected.size}, typescript found ${found.size}`);
+console.log(`\nmissed by typescript (${missed.length}):\n  ${missed.join('\n  ') || '(none)'}`);
+console.log(`\nfound only by typescript (${extra.length}):\n  ${extra.join('\n  ') || '(none)'}`);

--- a/src/base/config-action-discovery.ts
+++ b/src/base/config-action-discovery.ts
@@ -1,0 +1,207 @@
+import coreActions from './core-config-actions.json';
+
+/**
+ * Finds the config actions a recipe can use in this particular codebase.
+ *
+ * Three things produce an action name, and only the first can come from a
+ * static list:
+ *
+ *  - Drupal core, which is the same everywhere for a given core version.
+ *    core-config-actions.json is generated from core's source by
+ *    scripts/extract-config-actions.php, so it ships rather than being
+ *    rediscovered on every activation.
+ *  - A deriver that reads the installed entity types.
+ *    PermissionsPerBundleDeriver turns every bundle entity type into
+ *    grantPermissionsForEach<Bundle>, so the set differs per site and no
+ *    schema can ever hold it. These come from the config entities the YAML
+ *    scan has already found.
+ *  - A contrib or custom module that declares its own. Only reading that
+ *    module's PHP finds these.
+ *
+ * See docs/tracking-drupal-recipes.md.
+ */
+
+/** An action, and enough about it to explain itself in the completion list. */
+export interface DiscoveredAction {
+  name: string;
+  /** Where it came from, shown as the completion's documentation. */
+  origin: string;
+}
+
+/**
+ * The bundle entity types core generates per-bundle actions from.
+ *
+ * PermissionsPerBundleDeriver camelizes the bundle entity type id, so
+ * taxonomy_vocabulary becomes grantPermissionsForEachTaxonomyVocabulary. The
+ * config prefix is how the YAML scan recognises that the entity type is
+ * present at all.
+ */
+const BUNDLE_ENTITY_TYPES: { prefix: string; suffix: string }[] = [
+  { prefix: 'node.type.', suffix: 'NodeType' },
+  { prefix: 'taxonomy.vocabulary.', suffix: 'TaxonomyVocabulary' },
+  { prefix: 'media.type.', suffix: 'MediaType' },
+  { prefix: 'comment.type.', suffix: 'CommentType' },
+  { prefix: 'block_content.type.', suffix: 'BlockContentType' },
+  { prefix: 'contact.form.', suffix: 'ContactForm' },
+];
+
+/**
+ * A ConfigAction plugin declares its own id, unless it names a deriver, in
+ * which case the deriver decides and nothing static can say what it produces.
+ */
+const CONFIG_ACTION = /#\[ConfigAction\((?<args>[\s\S]*?)\)\]/g;
+
+/**
+ * An #[ActionMethod] attribute and the method it sits on. Other attributes may
+ * come between the two.
+ */
+const ACTION_METHOD =
+  /#\[ActionMethod\((?<args>[\s\S]*?)\)\]\s*(?:#\[[\s\S]*?\]\s*)*public function\s+(?<method>[A-Za-z0-9_]+)\s*\(/g;
+
+/**
+ * Pluralises an action name the way core does.
+ *
+ * EntityMethodDeriver runs the method name through Symfony's EnglishInflector,
+ * which is why hideComponents is a real action although that word appears
+ * nowhere in core. Only the handful of endings that occur on action names are
+ * covered; anything else keeps its own name, which is the safe direction to be
+ * wrong in, since offering a name that does not exist is worse than missing
+ * one that does.
+ *
+ * @param string name
+ *   The singular action name.
+ * @returns string
+ *   The plural, or an empty string when there is no sensible one.
+ */
+export function pluralise(name: string): string {
+  // A name already ending in s is left alone. Core's inflector would sometimes
+  // add -es here, but guessing wrong invents an action that does not exist,
+  // which is worse than missing one that does.
+  if (/s$/.test(name)) {
+    return '';
+  }
+
+  if (/(x|z|ch|sh)$/.test(name)) {
+    return `${name}es`;
+  }
+
+  if (/[^aeiou]y$/.test(name)) {
+    return `${name.slice(0, -1)}ies`;
+  }
+
+  return `${name}s`;
+}
+
+/**
+ * The actions declared by one PHP file.
+ *
+ * @param string source
+ *   The file contents.
+ * @param string origin
+ *   What to tell the user this file is, i.e. the module name.
+ * @returns DiscoveredAction[]
+ *   The actions the file declares, including pluralised aliases.
+ */
+export function actionsInPhp(source: string, origin: string): DiscoveredAction[] {
+  const found: DiscoveredAction[] = [];
+  const add = (name: string) => {
+    if (name !== '' && !found.some((a) => a.name === name)) {
+      found.push({ name, origin });
+    }
+  };
+
+  for (const match of source.matchAll(CONFIG_ACTION)) {
+    const args = match.groups?.args ?? '';
+
+    // A plugin with a deriver contributes no usable name of its own: the
+    // deriver decides, and it needs a running site to do so.
+    if (/deriver:/.test(args)) {
+      continue;
+    }
+
+    const id = /id:\s*'([^']+)'/.exec(args);
+
+    if (id !== null) {
+      // An entity-type-scoped id is written without its prefix in a recipe.
+      add(id[1].includes(':') ? id[1].split(':')[1] : id[1]);
+    }
+  }
+
+  for (const match of source.matchAll(ACTION_METHOD)) {
+    const args = match.groups?.args ?? '';
+    const explicit = /name:\s*'([^']+)'/.exec(args);
+    const name = explicit !== null ? explicit[1] : (match.groups?.method ?? '');
+
+    add(name);
+
+    if (/pluralize:\s*FALSE/i.test(args)) {
+      continue;
+    }
+
+    const given = /pluralize:\s*'([^']+)'/.exec(args);
+
+    add(given !== null ? given[1] : pluralise(name));
+  }
+
+  return found;
+}
+
+/**
+ * The per-bundle actions this codebase's entity types imply.
+ *
+ * @param Iterable<string> configNames
+ *   The config names the YAML scan has cached.
+ * @returns DiscoveredAction[]
+ *   One grantPermissionsForEach action per bundle entity type present.
+ */
+export function actionsFromBundles(
+  configNames: Iterable<string>
+): DiscoveredAction[] {
+  const present = new Set<string>();
+
+  for (const name of configNames) {
+    for (const { prefix, suffix } of BUNDLE_ENTITY_TYPES) {
+      // A bundle is one segment after the prefix; anything longer is some
+      // other config that merely starts the same way.
+      if (name.startsWith(prefix) && !name.slice(prefix.length).includes('.')) {
+        present.add(suffix);
+      }
+    }
+  }
+
+  return [...present].map((suffix) => ({
+    name: `grantPermissionsForEach${suffix}`,
+    origin: 'Generated from the entity types in this codebase',
+  }));
+}
+
+/**
+ * Every action available in this codebase.
+ *
+ * @param Iterable<string> configNames
+ *   The config names the YAML scan has cached.
+ * @param DiscoveredAction[] fromModules
+ *   Actions found by reading contrib and custom module PHP.
+ * @returns DiscoveredAction[]
+ *   Core's actions, plus what this codebase adds, without duplicates.
+ */
+export function collectActions(
+  configNames: Iterable<string>,
+  fromModules: DiscoveredAction[]
+): DiscoveredAction[] {
+  const byName = new Map<string, DiscoveredAction>();
+
+  for (const action of coreActions.actions) {
+    byName.set(action.name, { name: action.name, origin: 'Drupal core' });
+  }
+
+  // A module that redeclares a core action does not get to claim it twice, but
+  // the codebase's own actions are worth saying so about.
+  for (const action of [...actionsFromBundles(configNames), ...fromModules]) {
+    if (!byName.has(action.name)) {
+      byName.set(action.name, action);
+    }
+  }
+
+  return [...byName.values()].sort((a, b) => a.name.localeCompare(b.name));
+}

--- a/src/base/drupal-workspace-php-discovery.ts
+++ b/src/base/drupal-workspace-php-discovery.ts
@@ -1,0 +1,108 @@
+import { workspace } from 'vscode';
+import { addToCache, cacheItem } from '../utils/cache';
+import DrupalWorkspace from './drupal-workspace';
+import {
+  DiscoveredAction,
+  actionsInPhp,
+  collectActions,
+} from './config-action-discovery';
+
+/**
+ * Finds the config actions this codebase offers, and caches them as
+ * suggestions under config/actions/<config name>.
+ *
+ * Core's own actions ship as a generated list, so only contrib and custom
+ * modules are read here. That keeps the scan to a few hundred files rather
+ * than the whole of core, and it is the only part a static list cannot cover:
+ * a module that declares an action of its own.
+ */
+export class PhpDiscovery {
+  private drupalWorkspace: DrupalWorkspace;
+  private cache: Map<string, cacheItem[]>;
+
+  constructor(drupalWorkspace: DrupalWorkspace, cache: Map<string, cacheItem[]>) {
+    this.drupalWorkspace = drupalWorkspace;
+    this.cache = cache;
+  }
+
+  /**
+   * Reads the modules in the workspace and caches what they can do.
+   */
+  async discover(): Promise<DiscoveredAction[]> {
+    const fromModules = await this.actionsFromModules();
+    const actions = collectActions(this.cache.keys(), fromModules);
+
+    for (const action of actions) {
+      addToCache(
+        'config/actions/*',
+        '',
+        '',
+        action.name,
+        action.origin,
+        `${action.name}:\n  `,
+        'config_item',
+        this.cache
+      );
+    }
+
+    return actions;
+  }
+
+  /**
+   * The actions declared by contrib and custom modules in the workspace.
+   *
+   * Only files that mention an attribute are read, so the cost is a glob and a
+   * handful of reads rather than parsing everything.
+   */
+  private async actionsFromModules(): Promise<DiscoveredAction[]> {
+    // Core is excluded because its actions already ship; vendor and
+    // node_modules because nothing there is part of the site.
+    const files = await this.drupalWorkspace.findFiles(
+      '**/{modules,themes,profiles}/**/src/**/*.php',
+      '**/{vendor,node_modules,core}/**'
+    );
+
+    const found: DiscoveredAction[] = [];
+
+    for (const file of files) {
+      let source: string;
+
+      try {
+        const bytes = await workspace.fs.readFile(file);
+        source = Buffer.from(bytes).toString('utf8');
+      } catch {
+        // A file that has moved mid-scan is not worth failing the scan for.
+        continue;
+      }
+
+      // Cheap test before the expensive one: most PHP files declare nothing.
+      if (!source.includes('ConfigAction') && !source.includes('ActionMethod')) {
+        continue;
+      }
+
+      const module = this.moduleName(file.toString());
+
+      for (const action of actionsInPhp(source, `Provided by ${module}`)) {
+        if (!found.some((a) => a.name === action.name)) {
+          found.push(action);
+        }
+      }
+    }
+
+    return found;
+  }
+
+  /**
+   * The extension a file belongs to, taken from the directory above src/.
+   *
+   * @param string filePath
+   *   The file path.
+   * @returns string
+   *   The module name, or a readable fallback.
+   */
+  private moduleName(filePath: string): string {
+    const match = /\/([^/]+)\/src\//.exec(filePath);
+
+    return match !== null ? match[1] : 'a module in this codebase';
+  }
+}

--- a/src/providers/recipes-completion.ts
+++ b/src/providers/recipes-completion.ts
@@ -17,6 +17,7 @@ import {
   getInsertedValue,
 } from '../utils/utils';
 import { YamlDiscovery } from '../base/drupal-workspace-yaml-discovery';
+import { PhpDiscovery } from '../base/drupal-workspace-php-discovery';
 import { cacheItem } from '../utils/cache';
 import { getIconKind } from '../utils/icons';
 
@@ -26,6 +27,7 @@ export default class RecipesCompletionProvider
 {
   static language = 'yaml';
   private yamlDiscovery: YamlDiscovery;
+  private phpDiscovery: PhpDiscovery;
 
   cache: Map<string, cacheItem[]> = new Map();
 
@@ -49,7 +51,14 @@ export default class RecipesCompletionProvider
       this.drupalWorkspace,
       this.cache
     );
-    this.yamlDiscovery.parseYamlFiles();
+    this.phpDiscovery = new PhpDiscovery(this.drupalWorkspace, this.cache);
+
+    // The action discovery reads the config entities the YAML scan finds, so
+    // it has to follow it rather than run alongside.
+    this.yamlDiscovery
+      .parseYamlFiles()
+      .then(() => this.phpDiscovery.discover())
+      .catch((error) => console.error('Config action discovery failed', error));
   }
 
   /**
@@ -102,6 +111,12 @@ export default class RecipesCompletionProvider
     }
 
     let cachedItems = this.cache.get(propertyPath) || [];
+
+    // Action names apply to whatever config is being acted on, so they are
+    // cached once under a wildcard rather than per config name.
+    if (/^config\/actions\/[^/]+$/.test(propertyPath)) {
+      cachedItems = cachedItems.concat(this.cache.get('config/actions/*') ?? []);
+    }
 
     // Workaround to remove duplicated entries.
     // @todo Investigate why there are multiple duplications.

--- a/src/test/fixtures/drupal-site/web/modules/contrib/recipe_test_module/src/Entity/TestThing.php
+++ b/src/test/fixtures/drupal-site/web/modules/contrib/recipe_test_module/src/Entity/TestThing.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\recipe_test_module\Entity;
+
+use Drupal\Core\Config\Action\Attribute\ActionMethod;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
+/**
+ * Carries an ActionMethod, which is derived into an action and a plural alias.
+ */
+final class TestThing {
+
+  #[ActionMethod(adminLabel: new TranslatableMarkup('Set the widget'))]
+  public function setWidget(string $value): void {}
+
+}

--- a/src/test/fixtures/drupal-site/web/modules/contrib/recipe_test_module/src/Plugin/ConfigAction/TestAction.php
+++ b/src/test/fixtures/drupal-site/web/modules/contrib/recipe_test_module/src/Plugin/ConfigAction/TestAction.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\recipe_test_module\Plugin\ConfigAction;
+
+use Drupal\Core\Config\Action\Attribute\ConfigAction;
+use Drupal\Core\Config\Action\ConfigActionPluginInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
+/**
+ * A config action that only this codebase has, so no static list can know it.
+ */
+#[ConfigAction(
+  id: 'doSomethingModuleSpecific',
+  admin_label: new TranslatableMarkup('Do something module specific'),
+)]
+final class TestAction implements ConfigActionPluginInterface {
+
+  public function apply(string $configName, mixed $value): void {}
+
+}

--- a/src/test/integration/recipe-completion.test.ts
+++ b/src/test/integration/recipe-completion.test.ts
@@ -119,6 +119,23 @@ suite('Recipe completions', () => {
     ]);
   });
 
+  test('offers config actions from core, from this codebase, and from its modules', async () => {
+    // Issue #8. Three sources at once, at the same position:
+    //  - simpleConfigUpdate ships in the generated core list
+    //  - grantPermissionsForEachTaxonomyVocabulary exists only because the
+    //    fixture has a taxonomy vocabulary; no static list could know it
+    //  - doSomethingModuleSpecific and setWidget are declared in the fixture
+    //    module's own PHP
+    await completionLabelsAt(DYNAMIC, new vscode.Position(5, 48), [
+      'simpleConfigUpdate',
+      'grantPermissionsForEachTaxonomyVocabulary',
+      'grantPermissionsForEachMediaType',
+      'doSomethingModuleSpecific',
+      'setWidget',
+      'setWidgets',
+    ]);
+  });
+
   test('does not offer recipe suggestions outside a recipe file', async () => {
     const uri = vscode.Uri.joinPath(
       vscode.workspace.workspaceFolders![0].uri,

--- a/src/test/unit/config-action-discovery.test.ts
+++ b/src/test/unit/config-action-discovery.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect } from 'vitest';
+import {
+  actionsFromBundles,
+  actionsInPhp,
+  collectActions,
+  pluralise,
+} from '../../base/config-action-discovery';
+import coreActions from '../../base/core-config-actions.json';
+
+describe('pluralise', () => {
+  it.each([
+    ['grantPermission', 'grantPermissions'],
+    ['hideComponent', 'hideComponents'],
+    ['setThirdPartySetting', 'setThirdPartySettings'],
+    ['addImageEffect', 'addImageEffects'],
+    ['setFilterConfig', 'setFilterConfigs'],
+  ])('turns %s into %s', (singular, plural) => {
+    expect(pluralise(singular)).toBe(plural);
+  });
+
+  it('does not pluralise a name that already reads as one', () => {
+    expect(pluralise('setProperties')).toBe('');
+  });
+});
+
+describe('actionsInPhp', () => {
+  it('reads the id off a ConfigAction plugin', () => {
+    const source = `
+      #[ConfigAction(
+        id: 'doSomething',
+        admin_label: new TranslatableMarkup('Do something'),
+      )]
+      final class DoSomething implements ConfigActionPluginInterface {}
+    `;
+
+    expect(actionsInPhp(source, 'mymodule')).toEqual([
+      { name: 'doSomething', origin: 'mymodule' },
+    ]);
+  });
+
+  it('drops the entity type prefix from a scoped id', () => {
+    // editor:addItemToToolbar is written as addItemToToolbar in a recipe.
+    const source = "#[ConfigAction(id: 'editor:addItemToToolbar')]";
+
+    expect(actionsInPhp(source, 'x').map((a) => a.name)).toEqual([
+      'addItemToToolbar',
+    ]);
+  });
+
+  it('ignores a plugin whose names come from a deriver', () => {
+    // The deriver decides, and it needs a running site to do so.
+    const source = `
+      #[ConfigAction(
+        id: 'permissions_per_bundle',
+        deriver: PermissionsPerBundleDeriver::class,
+      )]
+    `;
+
+    expect(actionsInPhp(source, 'x')).toEqual([]);
+  });
+
+  it('reads an ActionMethod and its pluralised alias', () => {
+    const source = `
+      #[ActionMethod(adminLabel: new TranslatableMarkup('Set the thing'))]
+      public function setThing(string $value): void {}
+    `;
+
+    expect(actionsInPhp(source, 'x').map((a) => a.name)).toEqual([
+      'setThing',
+      'setThings',
+    ]);
+  });
+
+  it('honours pluralize: FALSE', () => {
+    const source = `
+      #[ActionMethod(pluralize: FALSE)]
+      public function setThing(string $value): void {}
+    `;
+
+    expect(actionsInPhp(source, 'x').map((a) => a.name)).toEqual(['setThing']);
+  });
+
+  it('honours an explicit plural', () => {
+    const source = `
+      #[ActionMethod(pluralize: 'addMultipleThings')]
+      public function addThing(string $value): void {}
+    `;
+
+    expect(actionsInPhp(source, 'x').map((a) => a.name)).toEqual([
+      'addThing',
+      'addMultipleThings',
+    ]);
+  });
+
+  it('honours an explicit name', () => {
+    const source = `
+      #[ActionMethod(name: 'reallyCalledThis')]
+      public function somethingElse(string $value): void {}
+    `;
+
+    expect(actionsInPhp(source, 'x').map((a) => a.name)).toContain(
+      'reallyCalledThis'
+    );
+  });
+
+  it('sees past another attribute between the two', () => {
+    const source = `
+      #[ActionMethod(exists: Exists::ErrorIfNotExists)]
+      #[SomethingElse]
+      public function setThing(string $value): void {}
+    `;
+
+    expect(actionsInPhp(source, 'x').map((a) => a.name)).toContain('setThing');
+  });
+
+  it('finds nothing in a file that declares nothing', () => {
+    expect(actionsInPhp('<?php class Foo { public function bar() {} }', 'x')).toEqual(
+      []
+    );
+  });
+});
+
+describe('actionsFromBundles', () => {
+  it('offers a per-bundle action for each entity type present', () => {
+    const names = [
+      'node.type.article',
+      'taxonomy.vocabulary.tags',
+      'system.site',
+    ];
+
+    expect(actionsFromBundles(names).map((a) => a.name).sort()).toEqual([
+      'grantPermissionsForEachNodeType',
+      'grantPermissionsForEachTaxonomyVocabulary',
+    ]);
+  });
+
+  it('offers nothing for an entity type that is not present', () => {
+    expect(actionsFromBundles(['system.site'])).toEqual([]);
+  });
+
+  it('does not mistake a longer config name that shares the prefix', () => {
+    expect(actionsFromBundles(['node.type.article.extra'])).toEqual([]);
+  });
+
+  it('offers each entity type once however many bundles it has', () => {
+    const names = ['node.type.article', 'node.type.page', 'node.type.blog'];
+
+    expect(actionsFromBundles(names)).toHaveLength(1);
+  });
+});
+
+describe('collectActions', () => {
+  it('includes every action core ships', () => {
+    const names = collectActions([], []).map((a) => a.name);
+
+    for (const action of coreActions.actions) {
+      expect(names).toContain(action.name);
+    }
+  });
+
+  it('adds what the codebase contributes', () => {
+    const actions = collectActions(
+      ['media.type.image'],
+      [{ name: 'somethingCustom', origin: 'Provided by mymodule' }]
+    );
+    const names = actions.map((a) => a.name);
+
+    expect(names).toContain('grantPermissionsForEachMediaType');
+    expect(names).toContain('somethingCustom');
+  });
+
+  it('does not let a module claim an action core already has', () => {
+    const actions = collectActions(
+      [],
+      [{ name: 'simpleConfigUpdate', origin: 'Provided by mymodule' }]
+    );
+    const matches = actions.filter((a) => a.name === 'simpleConfigUpdate');
+
+    expect(matches).toHaveLength(1);
+    expect(matches[0].origin).toBe('Drupal core');
+  });
+
+  it('returns them sorted, with no duplicates', () => {
+    const names = collectActions(['node.type.article'], []).map((a) => a.name);
+
+    expect(names).toEqual([...names].sort((a, b) => a.localeCompare(b)));
+    expect(new Set(names).size).toBe(names.length);
+  });
+});


### PR DESCRIPTION
Closes #8. Complements #39 rather than overlapping it: the schema covers what a static file can, this covers what it cannot.

## Two things no static list can hold

**Actions that depend on the site.** `PermissionsPerBundleDeriver` turns every bundle entity type into `grantPermissionsForEach<Bundle>`, so `grantPermissionsForEachMediaType` exists on a site with media and does not on one without. These are derived from the config entities the YAML scan already found — a `media.type.*` in the codebase means the action exists. Nothing had to be parsed for this.

**Actions a contrib or custom module declares.** Only that module's PHP says so. `PhpDiscovery` reads `#[ConfigAction]` and `#[ActionMethod]` from `**/{modules,themes,profiles}/**/src/**/*.php`, skipping `core` — its actions already ship in the generated list — and skipping any file that does not mention an attribute at all, which is nearly all of them.

Core's own actions are **not** rediscovered on activation. They come from `core-config-actions.json`, which is stable per core version and already committed.

## Matching, not parsing — and how that is kept honest

Taking the inspiration from your codegraph PR, the obvious choice was `web-tree-sitter` with the PHP grammar. I measured it first:

| | |
| --- | --- |
| Current bundle | **0.32 MB** |
| `web-tree-sitter` + PHP grammar | **~3 MB shipped** |

Roughly ten times the code size for two attribute shapes. So this ports the patterns from `scripts/extract-config-actions.php` instead — but that is only defensible while the two agree, so there is a script that checks:

```bash
node scripts/cross-check-discovery.mjs /path/to/drupal-core src/base/core-config-actions.json
```

Against `11.x` at `f0cc91d7ec9`, the commit the JSON was generated from:

```
scanned 44 php files with an attribute
php extractor found 52, typescript found 44

missed by typescript (8):
  addComponentsToLayout   addComponentToLayout   create   createForEach
  createForEachIfNotExists   createIfNotExists
  placeBlockInAdminTheme   placeBlockInDefaultTheme

found only by typescript (0):
  (none)
```

**No false positives, and no true misses** — all eight are deriver-produced names that a deriver decides at runtime, which is why both tools skip them and why they are folded into the committed list by hand.

Worth knowing: running that against a *different* core version reports four more misses (`setMessage`, `setRecipients`, `setRedirectPath`, `setReply`). Those are not failures — `contact` has left core in 12.x. The script's docblock says to match the commit for that reason, since I nearly drew the wrong conclusion from it myself.

If matching ever stops agreeing, tree-sitter is the answer and this script is how you would find out.

## Tests

23 unit tests over the matching: plugin ids, entity-scoped ids like `editor:addItemToToolbar`, deriver plugins being skipped, `pluralize: FALSE`, an explicit `pluralize:`, an explicit `name:`, an unrelated attribute sitting between the attribute and the method, and per-bundle derivation including the prefix guard.

Two bugs the tests caught while writing them:

- `pluralise('setProperties')` returned `setPropertieses`, because the `-es` rule ran before the already-plural check. It now bails on a name ending in `s` rather than guessing, since inventing an action that does not exist is worse than missing one that does.
- The sort assertion compared a `localeCompare` sort against a code-unit sort, which disagree on case. The test was wrong, not the code.

One integration test covers all three sources at one position: `simpleConfigUpdate` from the core list, `grantPermissionsForEachTaxonomyVocabulary` and `grantPermissionsForEachMediaType` from the fixture's entity types, and `doSomethingModuleSpecific` plus `setWidget`/`setWidgets` from PHP the fixture module declares.

`npm run typecheck`, `npm run lint` (0 errors, same 18 pre-existing warnings), `npm test` — **116 unit, 18 integration** — and `npm run verify:package` all pass.

## One thing to look at

Action names are cached once under `config/actions/*` and merged in when the path is `config/actions/<config name>`, since an action applies to whatever config is being acted on. That is a small change in `provideCompletionItems` and the place I would look first if something behaves oddly.
